### PR TITLE
chore: fix get quota usage for tyk 4.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,30 @@ This plugin is ready for translation and currently supports the following langua
 * German
 * French
 * Italian
+
+## Tyk API config
+
+There are two endpoints configured, one via the dashboard api (see TYK_API_ENDPOINT and tyk_api.php):
+
+`$this->api->get_url_for_path`
+
+For Authorization you need the Authorization header:
+
+`$api_response = wp_remote_post($this->get_url_for_path($path), array(
+	'headers' => array(
+		'Authorization' => TYK_API_KEY,
+	),
+));`
+
+and one for the gateway (see TYK_GATEWAY_URL and tyk_gateway.php):
+
+`$this->gateway->get_url_for_path`
+
+For Authorization you need the x-tyk-authorization header:
+
+`$api_response = wp_remote_get($this->get_url_for_path($path, $args), array(
+	'headers' => array(
+		'x-tyk-authorization' => TYK_GATEWAY_SECRET
+	),
+));`
+

--- a/classes/token.php
+++ b/classes/token.php
@@ -306,27 +306,25 @@ class Tyk_Token
 		try {
 			/**
 			 * Hybrid Tyk
-			 * Get usage quota from gateways, as this info isn't synced back to cloud
-			 */
-			if (Tyk_Dev_Portal::is_hybrid()) {
-				$response = $this->api->get(sprintf('/keys/%s', $this->key));
-				if (is_object($response) && isset($response->quota_remaining)) {
-					return (object) array(
-						'quota_remaining' => $response->quota_remaining,
-						'quota_max' => $response->quota_max
-						);
-				}
+             * Get usage quota from gateways, as this info isn't synced back to cloud
+             */
+            if (Tyk_Dev_Portal::is_hybrid()) {
+                $response = $this->api->get(sprintf('/keys/%s', $this->key));
+                if (is_object($response) && isset($response->quota_remaining)) {
+                    return (object)array(
+                        'quota_remaining' => $response->quota_remaining,
+                        'quota_max' => $response->quota_max
+                    );
+                }
                 if (is_object($response) && (isset($response->data->access_rights_array[0]->limit))) {
-                    return (object) array(
+                    return (object)array(
                         'quota_remaining' => $response->data->access_rights_array[0]->limit->quota_remaining,
                         'quota_max' => $response->data->access_rights_array[0]->limit->quota_max
                     );
+                } else {
+                    throw new Exception('Received invalid response from Gateway');
                 }
-				else {
-					throw new Exception('Received invalid response from Gateway');
-				}
-			}
-			/**
+            } /**
 			 * Cloud and on-premise Tyk
 			 * Get usage quota from API
 			 */


### PR DESCRIPTION
The new Tyk Dashboard API response json has changed and therefor we had to adjust the plugin regarding the quota usage, that could be seen on the developer dashboard, that the plugin provides. Old structure is still working, no Breaking Changes.

But in case you need to adjust your env vars see the Tyk config chapter in the README.