### PR TITLE
chore: use global quota for wp dev dashboard

### DIFF
--- a/classes/token.php
+++ b/classes/token.php
@@ -316,10 +316,10 @@ class Tyk_Token
                         'quota_max' => $response->quota_max
                     );
                 }
-                if (is_object($response) && (isset($response->data->access_rights_array[0]->limit))) {
+                if (is_object($response) && isset($response->data->quota_remaining) && isset($response->data->quota_max)) {
                     return (object)array(
-                        'quota_remaining' => $response->data->access_rights_array[0]->limit->quota_remaining,
-                        'quota_max' => $response->data->access_rights_array[0]->limit->quota_max
+                        'quota_remaining' => $response->data->quota_remaining,
+                        'quota_max' => $response->data->quota_max
                     );
                 } else {
                     throw new Exception('Received invalid response from Gateway');


### PR DESCRIPTION
For Tyk 4 you can use your old keys or the new ones. Depending on the type of key there are different json object structures.
For getting always the global quota, this adjustment is needed.