### PR TITLE
fix: concat org id and key for querying the quota for old keys

### DIFF
--- a/classes/token.php
+++ b/classes/token.php
@@ -303,6 +303,10 @@ class Tyk_Token
 		if (!is_string($this->key)) {
 			throw new InvalidArgumentException('Missing token key');
 		}
+		if (strlen($this->key) === 56) {
+			$this->key = TYK_ORG_ID.$this->key;
+			
+		}
 		try {
 			/**
 			 * Hybrid Tyk


### PR DESCRIPTION
This is a workaround for querying the key quota for old keys. The API changed with the new version of tyk and the old keys are now "hashed" with the organization id. 
Important: Add a env var TYK_ORG_ID to your wp.env and set the value of your org id for this.