### PR TITLE
fix: update Tyk delete API call for revoking a token

### DIFF
--- a/classes/api_manager.php
+++ b/classes/api_manager.php
@@ -1,70 +1,73 @@
 <?php
+
+declare(strict_types=1);
 /**
- * Tyk API manager
- *
- * @package Tyk_Dev_Portal\Tyk_API
+ * Tyk API manager.
  */
 
 /**
- * Handles API management, not actual API communication
+ * Handles API management, not actual API communication.
  */
-class Tyk_API_Manager 
+class Tyk_API_Manager
 {
-	/**
-	 * Name of tag that a policy must have on tyk api
-	 * so users may register for it freely
-	 */
-	const POLICY_TAG = 'allow_registration';
-	const TAC_TAG = 'requires_tac';
+    /**
+     * Name of tag that a policy must have on tyk api
+     * so users may register for it freely.
+     */
+    public const POLICY_TAG = 'allow_registration';
+    public const TAC_TAG = 'requires_tac';
 
-	/**
-	 * Get available policies defined on Tyk
-	 * 
-	 * @return array
-	 */
-	public static function available_policies() {
-		$tyk = new Tyk_API;
-		// available apis are actually available policies/plans that allow access
-		// to certain apis under certain restrictions
+    /**
+     * Get available policies defined on Tyk.
+     *
+     * @return array
+     */
+    public static function available_policies()
+    {
+        $tyk = new Tyk_API();
+        // available apis are actually available policies/plans that allow access
+        // to certain apis under certain restrictions
         // normally only the first 10 policies are returned, we disabled this limit using p=-1 as param
-		$response = $tyk->get('/portal/policies', ['p' => -1]);
-		// a generator would be nice here but alas, php 5.4 is still very common
-		$active_apis = array();
-		if (is_object($response) && isset($response->Data)) {
-			foreach ($response->Data as $policy) {
-				// only return active apis
-				if ($policy->active && !$policy->is_inactive) {
-					if (isset($policy->tags) && is_array($policy->tags) && in_array(self::POLICY_TAG, $policy->tags))
-					$active_apis[] = array(
-						'id' => $policy->_id,
-						'name' => $policy->name,
-						'requires_tac' => in_array(self::TAC_TAG, $policy->tags),
-						);
-				}
-			}
-		}
+        $response = $tyk->get('/portal/policies', array('p' => -1));
+        // a generator would be nice here but alas, php 5.4 is still very common
+        $active_apis = array();
+        if (is_object($response) && isset($response->Data)) {
+            foreach ($response->Data as $policy) {
+                // only return active apis
+                if ($policy->active && !$policy->is_inactive) {
+                    if (isset($policy->tags) && is_array($policy->tags) && in_array(self::POLICY_TAG, $policy->tags)) {
+                        $active_apis[] = array(
+                            'id' => $policy->_id,
+                            'name' => $policy->name,
+                            'requires_tac' => in_array(self::TAC_TAG, $policy->tags),
+                        );
+                    }
+                }
+            }
+        }
 
-		return $active_apis;
-	}
+        return $active_apis;
+    }
 
-	/**
-	 * Get APIs defined on Tyk
-	 *
-	 * @throws Exception When no apis are found in response
-	 * @return array
-	 */
-	public static function available_apis() {
-		$tyk = new Tyk_API;
-		$response = $tyk->get('/apis');
-		// a generator would be nice here but alas, php 5.4 is still very common
-		$apis = array();
-		if (is_object($response) && isset($response->apis)) {
-			return $response->apis;
-		}
-		else {
-			throw new Exception('No apis defined');
-		}
+    /**
+     * Get APIs defined on Tyk.
+     *
+     * @return array
+     *
+     * @throws Exception When no apis are found in response
+     */
+    public static function available_apis()
+    {
+        $tyk = new Tyk_API();
+        $response = $tyk->get('/apis');
+        // a generator would be nice here but alas, php 5.4 is still very common
+        $apis = array();
+        if (is_object($response) && isset($response->apis)) {
+            return $response->apis;
+        }
 
-		return $apis;
-	}
+        throw new Exception('No apis defined');
+
+        return $apis;
+    }
 }

--- a/classes/dashboard_ajax_provider.php
+++ b/classes/dashboard_ajax_provider.php
@@ -61,7 +61,7 @@ class Tyk_Dashboard_Ajax_Provider
 
 				wp_send_json_success(array(
 					'message' => $message,
-					'key' => $key,
+					'key' => $token->get_key(),
 					'approved' => TYK_AUTO_APPROVE_KEY_REQUESTS,
 					));
 			}

--- a/classes/dashboard_ajax_provider.php
+++ b/classes/dashboard_ajax_provider.php
@@ -1,186 +1,173 @@
 <?php
-/* vim: set noexpandtab tabstop=4 shiftwidth=4 sts=0 foldmethod=marker: */
+
+declare(strict_types=1);
+// vim: set noexpandtab tabstop=4 shiftwidth=4 sts=0 foldmethod=marker:
 
 /**
- * Provide ajax actions for dashboard GUI
+ * Provide ajax actions for dashboard GUI.
  */
-class Tyk_Dashboard_Ajax_Provider 
+class Tyk_Dashboard_Ajax_Provider
 {
-	/**
-	 * Register all supported ajax actions
-	 * 
-	 * @return void
-	 */
-	public function register_actions() {
-		// Process ajax actions
-		add_action('wp_ajax_get_token', array($this, 'register_for_api'));
-		add_action('wp_ajax_get_tokens', array($this, 'get_user_tokens'));
-		add_action('wp_ajax_get_available_apis', array($this, 'get_available_policies'));
-		add_action('wp_ajax_revoke_token', array($this, 'revoke_token'));
-		add_action('wp_ajax_get_token_usage', array($this, 'get_token_usage'));
-		add_action('wp_ajax_get_token_quota', array($this, 'get_token_quota'));
-	}
+    /**
+     * Register all supported ajax actions.
+     */
+    public function register_actions(): void
+    {
+        // Process ajax actions
+        add_action('wp_ajax_get_token', array($this, 'register_for_api'));
+        add_action('wp_ajax_get_tokens', array($this, 'get_user_tokens'));
+        add_action('wp_ajax_get_available_apis', array($this, 'get_available_policies'));
+        add_action('wp_ajax_revoke_token', array($this, 'revoke_token'));
+        add_action('wp_ajax_get_token_usage', array($this, 'get_token_usage'));
+        add_action('wp_ajax_get_token_quota', array($this, 'get_token_quota'));
+    }
 
-	/**
-	 * Ajax event-hook when "register for api" form is submitted:
-	 * Request a user-token for the corresponding tyk API
-	 *
-	 * @return void Sends output to output buffer
-	 */
-	public function register_for_api() {
-		$response = array();
-		// @todo check if this is a valid api
-		if (isset($_POST['api'])) {
-			try {
-				$user = new Tyk_Portal_User();
-				$token = new Tyk_Token($user, $_POST['api']);
-				$token->request();
+    /**
+     * Ajax event-hook when "register for api" form is submitted:
+     * Request a user-token for the corresponding tyk API
+     */
+    public function register_for_api(): void
+    {
+        $response = array();
+        // @todo check if this is a valid api
+        if (isset($_POST['api'])) {
+            try {
+                $user = new Tyk_Portal_User();
+                $token = new Tyk_Token($user, $_POST['api']);
+                $token->request();
 
-				// when keys are approved automatically
-				if (TYK_AUTO_APPROVE_KEY_REQUESTS) {
-					$token->approve();
-					// save the access token information
-					$user->save_access_token($_POST['api'], $_POST['token_name'], $token->get_hash());
+                // when keys are approved automatically
+                if (TYK_AUTO_APPROVE_KEY_REQUESTS) {
+                    $token->approve();
+                    // save the access token information
+                    $user->save_access_token($_POST['api'], $_POST['token_name'], $token->get_hash());
 
-					// we removed the dot for User Experience,
-					// since the User copies the dot with the key and therefore the key is corupted.
-					$message = sprintf(
-						__('Your token for this API is: %s and we will only show this once. Please save it somewhere now.', Tyk_Dev_Portal::TEXT_DOMAIN), 
-				
-						$token->get_key()
-						);
-				}
-				// when keys await manual approval
-				else {
-					$message = sprintf(
-						__('Your key request is pending review. You will receive an Email when your request is processed. Your request id is %s. This is not your access token. Please refer to the request ID when contacting us by Email.', 
-						Tyk_Dev_Portal::TEXT_DOMAIN),
-						$token->get_id()
-						);
-				}
+                    // we removed the dot for User Experience,
+                    // since the User copies the dot with the key and therefore the key is corupted.
+                    $message = sprintf(
+                        __('Your token for this API is: %s and we will only show this once. Please save it somewhere now.', Tyk_Dev_Portal::TEXT_DOMAIN),
+                        $token->get_key(),
+                    );
+                }
+                // when keys await manual approval
+                else {
+                    $message = sprintf(
+                        __(
+                            'Your key request is pending review. You will receive an Email when your request is processed. Your request id is %s. This is not your access token. Please refer to the request ID when contacting us by Email.',
+                            Tyk_Dev_Portal::TEXT_DOMAIN,
+                        ),
+                        $token->get_id(),
+                    );
+                }
 
-				wp_send_json_success(array(
-					'message' => $message,
-					'key' => $token->get_key(),
-					'approved' => TYK_AUTO_APPROVE_KEY_REQUESTS,
-					));
-			}
-			catch (Exception $e) {
-				wp_send_json_error($e->getMessage());
-			}
-		}
-		wp_send_json_error(__('Invalid request'));
-	}
+                wp_send_json_success(array(
+                    'message' => $message,
+                    'key' => $token->get_key(),
+                    'approved' => TYK_AUTO_APPROVE_KEY_REQUESTS,
+                ));
+            } catch (Exception $e) {
+                wp_send_json_error($e->getMessage());
+            }
+        }
+        wp_send_json_error(__('Invalid request'));
+    }
 
-	/**
-	 * Get user tokens
-	 * 
-	 * @return void
-	 */
-	public function get_user_tokens() {
-		try {
-			$user = new Tyk_Portal_User();
-			wp_send_json_success($user->get_access_tokens());
-		}
-		catch (Exception $e) {
-			wp_send_json_error(sprintf('An error occured: %s', $e->getMessage()));
-		}
-	}
+    /**
+     * Get user tokens.
+     */
+    public function get_user_tokens(): void
+    {
+        try {
+            $user = new Tyk_Portal_User();
+            wp_send_json_success($user->get_access_tokens());
+        } catch (Exception $e) {
+            wp_send_json_error(sprintf('An error occured: %s', $e->getMessage()));
+        }
+    }
 
-	/**
-	 * Get available policies
-	 * These are communicated as APIs to the user because that's what they're interested in
-	 * 
-	 * @return void
-	 */
-	public function get_available_policies() {
-		try {
-			wp_send_json_success(Tyk_API_Manager::available_policies());
-		}
-		catch (Exception $e) {
-			wp_send_json_error(sprintf('An error occured: %s', $e->getMessage()));
-		}
-	}
+    /**
+     * Get available policies
+     * These are communicated as APIs to the user because that's what they're interested in.
+     */
+    public function get_available_policies(): void
+    {
+        try {
+            wp_send_json_success(Tyk_API_Manager::available_policies());
+        } catch (Exception $e) {
+            wp_send_json_error(sprintf('An error occured: %s', $e->getMessage()));
+        }
+    }
 
-	/**
-	 * Revoke a user token
-	 * 
-	 * @return void
-	 */
-	public function revoke_token() {
-		if (isset($_POST['token'])) {
-			try {
-				$user = new Tyk_Portal_User();
-				// revoke token on tyk api
-				// this will throw an exception if token is invalid or revoking fails
-				$token = $user->get_access_token($_POST['token']);
-				$token->revoke();
-			}
-			catch (Exception $e) {
-				// treat everything as an error except when tyk can't find the token
-				// in which case we'll assume it's gone on their side and delete it on our side as well
-				if (strpos(strtolower($e->getMessage()), 'not found') === false) {
-					wp_send_json_error($e->getMessage());
-				}
-			}
-			// we can't assume PHP 5.5 otherwise we could use the finally directive
+    /**
+     * Revoke a user token.
+     */
+    public function revoke_token(): void
+    {
+        if (isset($_POST['token'])) {
+            try {
+                $user = new Tyk_Portal_User();
+                // revoke token on tyk api
+                // this will throw an exception if token is invalid or revoking fails
+                $token = $user->get_access_token($_POST['token']);
+                $token->revoke();
+            } catch (Exception $e) {
+                // treat everything as an error except when tyk can't find the token
+                // in which case we'll assume it's gone on their side and delete it on our side as well
+                if (false === strpos(strtolower($e->getMessage()), 'not found')) {
+                    wp_send_json_error($e->getMessage());
+                }
+            }
+            // we can't assume PHP 5.5 otherwise we could use the finally directive
 
-			// delete local storage of hashed token
-			$user->delete_access_token($_POST['token']);
-			$message = sprintf(__('Your token "%s" was revoked permanently and is invalidated effective immediately.', Tyk_Dev_Portal::TEXT_DOMAIN), $token->get_name());
-			wp_send_json_success(array(
-				'message' => $message,
-				));
-		}
-		wp_send_json_error(__('Invalid request'));
-	}
+            // delete local storage of hashed token
+            $user->delete_access_token($_POST['token']);
+            $message = sprintf(__('Your token "%s" was revoked permanently and is invalidated effective immediately.', Tyk_Dev_Portal::TEXT_DOMAIN), $token->get_name());
+            wp_send_json_success(array(
+                'message' => $message,
+            ));
+        }
+        wp_send_json_error(__('Invalid request'));
+    }
 
-	/**
-	 * Get usage quota
-	 * 
-	 * @return void
-	 */
-	public function get_token_quota() {
-		if (isset($_POST['token'])) {
-			try {
-				$user = new Tyk_Portal_User();
-				$token = Tyk_Token::init_from_key(sanitize_text_field($_POST['token']), $user);
-				wp_send_json_success($token->get_usage_quota());
-			}
-			catch (Exception $e) {
-				if (strtolower($e->getMessage()) != 'not found') {
-					wp_send_json_error($e->getMessage());
-				}
-				else {
-					wp_send_json_error(__('Token could not be found. Please note that you must use the token at least once before you can request the remaining quota.', Tyk_Dev_Portal::TEXT_DOMAIN));
-				}
-			}
-		}
-		wp_send_json_error(__('Invalid request'));
-	}
+    /**
+     * Get usage quota.
+     */
+    public function get_token_quota(): void
+    {
+        if (isset($_POST['token'])) {
+            try {
+                $user = new Tyk_Portal_User();
+                $token = Tyk_Token::init_from_key(sanitize_text_field($_POST['token']), $user);
+                wp_send_json_success($token->get_usage_quota());
+            } catch (Exception $e) {
+                if ('not found' != strtolower($e->getMessage())) {
+                    wp_send_json_error($e->getMessage());
+                } else {
+                    wp_send_json_error(__('Token could not be found. Please note that you must use the token at least once before you can request the remaining quota.', Tyk_Dev_Portal::TEXT_DOMAIN));
+                }
+            }
+        }
+        wp_send_json_error(__('Invalid request'));
+    }
 
-	/**
-	 * Get token usage
-	 * 
-	 * @return void
-	 */
-	public function get_token_usage() {
-		if (isset($_GET['token'])) {
-			try {
-				$from_date = isset($_GET['from'])
-					? $_GET['from']
-					: null;
-				$to_date = isset($_GET['to'])
-					? $_GET['to']
-					: null;
-				$user = new Tyk_Portal_User();
-				$token = $user->get_access_token($_GET['token']);
-				wp_send_json_success($token->get_usage($from_date, $to_date));
-			}
-			catch (Exception $e) {
-				wp_send_json_error($e->getMessage());
-			}
-		}
-		wp_send_json_error(__('Invalid request'));
-	}
+    /**
+     * Get token usage.
+     */
+    public function get_token_usage(): void
+    {
+        if (isset($_GET['token'])) {
+            try {
+                $from_date = $_GET['from']
+                    ?? null;
+                $to_date = $_GET['to']
+                    ?? null;
+                $user = new Tyk_Portal_User();
+                $token = $user->get_access_token($_GET['token']);
+                wp_send_json_success($token->get_usage($from_date, $to_date));
+            } catch (Exception $e) {
+                wp_send_json_error($e->getMessage());
+            }
+        }
+        wp_send_json_error(__('Invalid request'));
+    }
 }

--- a/classes/dev_portal.php
+++ b/classes/dev_portal.php
@@ -1,8 +1,8 @@
 <?php
+
+declare(strict_types=1);
 /**
- * Contains the "plugin manager" class
- * 
- * @package Tyk_Dev_Portal\WordPress
+ * Contains the "plugin manager" class.
  */
 
 /**
@@ -12,260 +12,253 @@
  */
 class Tyk_Dev_Portal
 {
-	/**
-	 * Name of this plugin
-	 */
-	const PLUGIN_NAME = 'Tyk Developer Portal';
+    /**
+     * Name of this plugin.
+     */
+    public const PLUGIN_NAME = 'Tyk Developer Portal';
 
-	/**
-	 * Version of this plugin
-	 */
-	const PLUGIN_VERSION = '1.2';
+    /**
+     * Version of this plugin.
+     */
+    public const PLUGIN_VERSION = '1.2';
 
-	/**
-	 * Slug of the dashboard page
-	 */
-	const DASHBOARD_SLUG = 'dev-dashboard';
+    /**
+     * Slug of the dashboard page.
+     */
+    public const DASHBOARD_SLUG = 'dev-dashboard';
 
-	/**
-	 * This plugins text domain
-	 */
-	const TEXT_DOMAIN = 'tyk-dev-portal';
+    /**
+     * This plugins text domain.
+     */
+    public const TEXT_DOMAIN = 'tyk-dev-portal';
 
-	/**
-	 * Name of the role for developers this plugin will create
-	 */
-	const DEVELOPER_ROLE_NAME = 'developer';
+    /**
+     * Name of the role for developers this plugin will create.
+     */
+    public const DEVELOPER_ROLE_NAME = 'developer';
 
-	/**
-	 * Tyk configuration types
-	 * we use these for consistency when checking TYK_CONFIGURATION throughout the code
-	 */
-	const CONFIGURATION_ON_PREMISE = 'on-premise';
-	const CONFIGURATION_HYBRID = 'hybrid';
-	const CONFIGURATION_CLOUD = 'cloud';
+    /**
+     * Tyk configuration types
+     * we use these for consistency when checking TYK_CONFIGURATION throughout the code.
+     */
+    public const CONFIGURATION_ON_PREMISE = 'on-premise';
+    public const CONFIGURATION_HYBRID = 'hybrid';
+    public const CONFIGURATION_CLOUD = 'cloud';
 
-	/**
-	 * Register any hooks
-	 * 
-	 * @return void
-	 */
-	public function register_hooks() {
-		// in backend: register activation hook for this plugin
-		if (is_admin()) {
-			register_activation_hook(TYK_DEV_PORTAL_PLUGIN_FILE, array($this, 'activate_plugin'));
-		}
-	}
+    /**
+     * Register any hooks.
+     */
+    public function register_hooks(): void
+    {
+        // in backend: register activation hook for this plugin
+        if (is_admin()) {
+            register_activation_hook(TYK_DEV_PORTAL_PLUGIN_FILE, array($this, 'activate_plugin'));
+        }
+    }
 
-	/**
-	 * Register any actions
-	 * 
-	 * @return void
-	 */
-	public function register_actions() {
-		/**
-		 * Hook into wordpress "onregister" of a user and register the
-	 	 * user as a tyk developer if the user has the "developer" role
-		 */
-		add_action('user_register', array($this, 'register_user_with_tyk'));
+    /**
+     * Register any actions.
+     */
+    public function register_actions(): void
+    {
+        /*
+         * Hook into wordpress "onregister" of a user and register the
+         * user as a tyk developer if the user has the "developer" role
+         */
+        add_action('user_register', array($this, 'register_user_with_tyk'));
 
-		$dashboard_ajax_provider = new Tyk_Dashboard_Ajax_Provider;
-		$dashboard_ajax_provider->register_actions();
+        $dashboard_ajax_provider = new Tyk_Dashboard_Ajax_Provider();
+        $dashboard_ajax_provider->register_actions();
 
-		add_action('init', array($this, 'register_scripts'));
-		add_action('init', array($this, 'register_styles'));
-		add_action('wp', array($this, 'enqueue_assets'));
-		add_action('wp', array($this, 'environment_is_ready'));
-		add_action('plugins_loaded', array($this, 'load_plugin_textdomain'));
-	}
+        add_action('init', array($this, 'register_scripts'));
+        add_action('init', array($this, 'register_styles'));
+        add_action('wp', array($this, 'enqueue_assets'));
+        add_action('wp', array($this, 'environment_is_ready'));
+        add_action('plugins_loaded', array($this, 'load_plugin_textdomain'));
+    }
 
-	/**
-	 * Register any shortcodes
-	 * 
-	 * @return void
-	 */
-	public function register_shortcodes() {
-		add_shortcode('tyk_dev_dashboard', 'tyk_dev_portal_dashboard');
-	}
+    /**
+     * Register any shortcodes.
+     */
+    public function register_shortcodes(): void
+    {
+        add_shortcode('tyk_dev_dashboard', 'tyk_dev_portal_dashboard');
+    }
 
-	/**
-	 * Make sure environment is ready for our plugin
-	 * 
-	 * @return void
-	 */
-	public function environment_is_ready() {
-		// make sure we have a tyk user in case registration failed
-		$this->register_user_with_tyk();
-	}
+    /**
+     * Make sure environment is ready for our plugin.
+     */
+    public function environment_is_ready(): void
+    {
+        // make sure we have a tyk user in case registration failed
+        $this->register_user_with_tyk();
+    }
 
-	/**
-	 * Enqueue scripts and styles for the appropriate page
-	 *
-	 * We do this in 'wp' hook because it's after the theme has setup
-	 * and enqueued it's styles so we can react accordingly.
-	 * 
-	 * @return void
-	 */
-	public function enqueue_assets() {
-		$user = new Tyk_Portal_User;
-		// if this is our dashboard page, enqueue our assets
-		if ($user->is_logged_in() && is_page(self::DASHBOARD_SLUG)) {
-			// enqueue and localize our dashboard script
-			wp_enqueue_script('tyk-dev-portal-dashboard');
-			$params = array(
-				'actionUrl'           => esc_url(admin_url('admin-ajax.php')),
-				'label_used'          => __('Used', self::TEXT_DOMAIN),
-				'label_remaining'     => __('Remaining', self::TEXT_DOMAIN),
-				'label_success'       => __('Success', self::TEXT_DOMAIN),
-				'label_errors'        => __('Errors', self::TEXT_DOMAIN),
-				'error_invalid_data'  => __('Invalid or insufficient data', self::TEXT_DOMAIN),
-				'label_valid'         => __('valid', Tyk_Dev_Portal::TEXT_DOMAIN),
-				'label_invalid'       => __('invalid', Tyk_Dev_Portal::TEXT_DOMAIN),
-				'msg_unlimited_quota' => __('This token has unlimited quota', Tyk_Dev_Portal::TEXT_DOMAIN),
-				);
-			wp_localize_script('tyk-dev-portal-dashboard', 'scriptParams', $params);
+    /**
+     * Enqueue scripts and styles for the appropriate page.
+     *
+     * We do this in 'wp' hook because it's after the theme has setup
+     * and enqueued it's styles so we can react accordingly.
+     */
+    public function enqueue_assets(): void
+    {
+        $user = new Tyk_Portal_User();
+        // if this is our dashboard page, enqueue our assets
+        if ($user->is_logged_in() && is_page(self::DASHBOARD_SLUG)) {
+            // enqueue and localize our dashboard script
+            wp_enqueue_script('tyk-dev-portal-dashboard');
+            $params = array(
+                'actionUrl'           => esc_url(admin_url('admin-ajax.php')),
+                'label_used'          => __('Used', self::TEXT_DOMAIN),
+                'label_remaining'     => __('Remaining', self::TEXT_DOMAIN),
+                'label_success'       => __('Success', self::TEXT_DOMAIN),
+                'label_errors'        => __('Errors', self::TEXT_DOMAIN),
+                'error_invalid_data'  => __('Invalid or insufficient data', self::TEXT_DOMAIN),
+                'label_valid'         => __('valid', Tyk_Dev_Portal::TEXT_DOMAIN),
+                'label_invalid'       => __('invalid', Tyk_Dev_Portal::TEXT_DOMAIN),
+                'msg_unlimited_quota' => __('This token has unlimited quota', Tyk_Dev_Portal::TEXT_DOMAIN),
+            );
+            wp_localize_script('tyk-dev-portal-dashboard', 'scriptParams', $params);
 
-			wp_enqueue_script('chart.js');
+            wp_enqueue_script('chart.js');
 
-			// only enqueue our bootstrap styles if the current theme isn't using bootstrap
-			if (!wp_style_is('bootstrap', 'enqueued')) {
-				if (!defined('TYK_FORCE_DISABLE_BOOTSTRAP') || TYK_FORCE_DISABLE_BOOTSTRAP !== true) {
-					wp_enqueue_style('tyk-dev-portal-bootstrap');
-				}
-			}
-		}
-	}
+            // only enqueue our bootstrap styles if the current theme isn't using bootstrap
+            if (!wp_style_is('bootstrap', 'enqueued')) {
+                if (!defined('TYK_FORCE_DISABLE_BOOTSTRAP') || TYK_FORCE_DISABLE_BOOTSTRAP !== true) {
+                    wp_enqueue_style('tyk-dev-portal-bootstrap');
+                }
+            }
+        }
+    }
 
-	/**
-	 * Register javascript files
-	 * 
-	 * @return void
-	 */
-	public function register_scripts() {
-		// enqueue vue.js
-		$vue_file = (WP_DEBUG === true)
-			? 'vue.js'
-			: 'vue.min.js';
-		$vendor_version = (WP_DEBUG === true)
-			? time()
-			: self::PLUGIN_VERSION;
-		wp_register_script('vue', tyk_dev_portal_plugin_url('assets/js/vendor/' . $vue_file), array(), $vendor_version, true);
-		wp_register_script('underscore', tyk_dev_portal_plugin_url('assets/js/vendor/underscore.min.js'), array(), $vendor_version, true);
+    /**
+     * Register javascript files.
+     */
+    public function register_scripts(): void
+    {
+        // enqueue vue.js
+        $vue_file = (WP_DEBUG === true)
+            ? 'vue.js'
+            : 'vue.min.js';
+        $vendor_version = (WP_DEBUG === true)
+            ? time()
+            : self::PLUGIN_VERSION;
+        wp_register_script('vue', tyk_dev_portal_plugin_url('assets/js/vendor/' . $vue_file), array(), $vendor_version, true);
+        wp_register_script('underscore', tyk_dev_portal_plugin_url('assets/js/vendor/underscore.min.js'), array(), $vendor_version, true);
 
-		wp_register_script('chart.js', tyk_dev_portal_plugin_url('assets/js/vendor/chart.min.js'), array(), $vendor_version, false);
-		
-		// enqueue dashboard.js
-		$dashboard_ver = (WP_DEBUG === true)
-			? time()
-			: self::PLUGIN_VERSION;
-		wp_register_script('tyk-dev-portal-dashboard', tyk_dev_portal_plugin_url('assets/js/dashboard.js'), array('jquery', 'vue', 'underscore'), $dashboard_ver, true);
-	}
+        wp_register_script('chart.js', tyk_dev_portal_plugin_url('assets/js/vendor/chart.min.js'), array(), $vendor_version, false);
 
-	/**
-	 * Register styles
-	 * 
-	 * Registers a minimal bootstrap theme that only contains the stuff we need
-	 * Note: this style is only enqueued if the activate theme does not enqueue a bootstrap file
-	 * 
-	 * @return void
-	 */
-	public function register_styles() {
-		$style_ver = (WP_DEBUG === true)
-			? time()
-			: self::PLUGIN_VERSION;
-		wp_register_style('tyk-dev-portal-bootstrap', tyk_dev_portal_plugin_url('assets/css/bootstrap.min.css'), null, $style_ver);
-	}
+        // enqueue dashboard.js
+        $dashboard_ver = (WP_DEBUG === true)
+            ? time()
+            : self::PLUGIN_VERSION;
+        wp_register_script('tyk-dev-portal-dashboard', tyk_dev_portal_plugin_url('assets/js/dashboard.js'), array('jquery', 'vue', 'underscore'), $dashboard_ver, true);
+    }
 
-	/**
-	 * load the localized strings
-	 *
-	 * @return void
-	 */
-	public function load_plugin_textdomain() {
-	    load_plugin_textdomain(self::TEXT_DOMAIN, FALSE, basename(TYK_DEV_PORTAL_PLUGIN_PATH) . '/languages');
-	}
+    /**
+     * Register styles.
+     *
+     * Registers a minimal bootstrap theme that only contains the stuff we need
+     * Note: this style is only enqueued if the activate theme does not enqueue a bootstrap file
+     */
+    public function register_styles(): void
+    {
+        $style_ver = (WP_DEBUG === true)
+            ? time()
+            : self::PLUGIN_VERSION;
+        wp_register_style('tyk-dev-portal-bootstrap', tyk_dev_portal_plugin_url('assets/css/bootstrap.min.css'), null, $style_ver);
+    }
 
-	/**
-	 * Register a user as a developer with Tyk
-	 * 
-	 * @param integer $user_id
-	 * @return void
-	 */
-	public function register_user_with_tyk($user_id = null) {
-		$user = new Tyk_Portal_User($user_id);
-		if ($user->is_logged_in() && !$user->has_tyk_id()) {
-			$user->register_with_tyk();
-		}
-	}
+    /**
+     * load the localized strings.
+     */
+    public function load_plugin_textdomain(): void
+    {
+        load_plugin_textdomain(self::TEXT_DOMAIN, false, basename(TYK_DEV_PORTAL_PLUGIN_PATH) . '/languages');
+    }
 
-	/**
-	 * Hook that is fired when this plugin is activated
-	 * 
-	 * @return void
-	 */
-	public function activate_plugin() {
-		$this->create_developer_role();
-		$this->create_dashboard_page();
-	}
+    /**
+     * Register a user as a developer with Tyk.
+     *
+     * @param int $user_id
+     */
+    public function register_user_with_tyk($user_id = null): void
+    {
+        $user = new Tyk_Portal_User($user_id);
+        if ($user->is_logged_in() && !$user->has_tyk_id()) {
+            $user->register_with_tyk();
+        }
+    }
 
-	/**
-	 * Create a role "developer"
-	 * 
-	 * @return void
-	 */
-	public function create_developer_role() {
-		$result = add_role(self::DEVELOPER_ROLE_NAME, __('Developer', self::TEXT_DOMAIN));
-		if ($result === false) {
-			trigger_error(sprintf('Could not create role "%s" for plugin %s',
-				self::DEVELOPER_ROLE_NAME,
-				self::PLUGIN_NAME
-			));
-		}
-	}
+    /**
+     * Hook that is fired when this plugin is activated.
+     */
+    public function activate_plugin(): void
+    {
+        $this->create_developer_role();
+        $this->create_dashboard_page();
+    }
 
-	/**
-	 * Create a page for the developer dashboard
-	 * 
-	 * @return void
-	 */
-	public function create_dashboard_page() {
-		// @todo check if the page already exists
-		$page = array(
-			'post_title' => __('Developer Dashboard', self::TEXT_DOMAIN),
-			'post_name' => self::DASHBOARD_SLUG,
-			'post_content' => '[tyk_dev_dashboard]',
-			'post_status' => 'publish',
-			'post_type' => 'page',
-			'post_author' => 1, // @todo get an admin user id here
-		);
-		$post_id = wp_insert_post($page);
-		// @todo we should probably save the slug of the created page here
-	}
+    /**
+     * Create a role "developer".
+     */
+    public function create_developer_role(): void
+    {
+        $result = add_role(self::DEVELOPER_ROLE_NAME, __('Developer', self::TEXT_DOMAIN));
+        if (false === $result) {
+            trigger_error(sprintf(
+                'Could not create role "%s" for plugin %s',
+                self::DEVELOPER_ROLE_NAME,
+                self::PLUGIN_NAME,
+            ));
+        }
+    }
 
-	/**
-	 * Are we using Tyk Cloud?
-	 * 
-	 * @return boolean
-	 */
-	public static function is_cloud() {
-		return strtolower(TYK_CONFIGURATION) == self::CONFIGURATION_CLOUD;
-	}
+    /**
+     * Create a page for the developer dashboard.
+     */
+    public function create_dashboard_page(): void
+    {
+        // @todo check if the page already exists
+        $page = array(
+            'post_title' => __('Developer Dashboard', self::TEXT_DOMAIN),
+            'post_name' => self::DASHBOARD_SLUG,
+            'post_content' => '[tyk_dev_dashboard]',
+            'post_status' => 'publish',
+            'post_type' => 'page',
+            'post_author' => 1, // @todo get an admin user id here
+        );
+        $post_id = wp_insert_post($page);
+        // @todo we should probably save the slug of the created page here
+    }
 
-	/**
-	 * Are we using Tyk Hybrid?
-	 * 
-	 * @return boolean
-	 */
-	public static function is_hybrid() {
-		return strtolower(TYK_CONFIGURATION) == self::CONFIGURATION_HYBRID;	
-	}
+    /**
+     * Are we using Tyk Cloud?
+     *
+     * @return bool
+     */
+    public static function is_cloud()
+    {
+        return self::CONFIGURATION_CLOUD == strtolower(TYK_CONFIGURATION);
+    }
 
-	/**
-	 * Are we using Tyk On-Premise?
-	 * 
-	 * @return boolean
-	 */
-	public static function is_on_premise() {
-		return strtolower(TYK_CONFIGURATION) == self::CONFIGURATION_ON_PREMISE;
-	}
+    /**
+     * Are we using Tyk Hybrid?
+     *
+     * @return bool
+     */
+    public static function is_hybrid()
+    {
+        return self::CONFIGURATION_HYBRID == strtolower(TYK_CONFIGURATION);
+    }
+
+    /**
+     * Are we using Tyk On-Premise?
+     *
+     * @return bool
+     */
+    public static function is_on_premise()
+    {
+        return self::CONFIGURATION_ON_PREMISE == strtolower(TYK_CONFIGURATION);
+    }
 }

--- a/classes/portal_user.php
+++ b/classes/portal_user.php
@@ -1,256 +1,273 @@
 <?php
+
+declare(strict_types=1);
 /**
- * Tyk portal user
- *
- * @package Tyk_Dev_Portal\Tyk_User
+ * Tyk portal user.
  */
 
 /**
  * Not an actual user abstraction, but gathers common functionality regarding
- * developer portal users
+ * developer portal users.
  */
-class Tyk_Portal_User 
+class Tyk_Portal_User
 {
-	/**
-	 * The name of the key in wordpress user meta data where tyk user id is stored
-	 */
-	const META_TYK_USER_ID_KEY = 'tyk_user_id';
+    /**
+     * The name of the key in wordpress user meta data where tyk user id is stored.
+     */
+    public const META_TYK_USER_ID_KEY = 'tyk_user_id';
 
-	/**
-	 * The name of the key in wordpress user meta data where tyk access tokens are stored
-	 * Note that the actual tokens are not stored, just the name and id so we can manage them
-	 */
-	const META_TYK_ACCESS_TOKENS_KEY = 'tyk_access_token';
+    /**
+     * The name of the key in wordpress user meta data where tyk access tokens are stored
+     * Note that the actual tokens are not stored, just the name and id so we can manage them.
+     */
+    public const META_TYK_ACCESS_TOKENS_KEY = 'tyk_access_token';
 
-	/**
-	 * Name of the developer role this plugin creates
-	 */
-	const DEVELOPER_ROLE_NAME = 'developer';
+    /**
+     * Name of the developer role this plugin creates.
+     */
+    public const DEVELOPER_ROLE_NAME = 'developer';
 
-	/**
-	 * The actual wordpress user object
-	 * 
-	 * @var WP_User
-	 */
-	private $user;
+    /**
+     * The actual wordpress user object.
+     *
+     * @var WP_User
+     */
+    private $user;
 
-	/**
-	 * User's policy subscriptions according to Tyk
-	 * @var Array
-	 */
-	private $tyk_subscriptions;
+    /**
+     * User's policy subscriptions according to Tyk.
+     *
+     * @var array
+     */
+    private $tyk_subscriptions;
 
-	/**
-	 * Setup portal user
-	 * 
-	 * @param integer $user_id Defaults to current user's id
-	 */
-	public function __construct($user_id = null) {
-		if (is_null($user_id)) {
-			$user_id = get_current_user_id();
-		}
-		$this->user = get_userdata($user_id);
-	}
+    /**
+     * Setup portal user.
+     *
+     * @param int $user_id Defaults to current user's id
+     */
+    public function __construct($user_id = null)
+    {
+        if (is_null($user_id)) {
+            $user_id = get_current_user_id();
+        }
+        $this->user = get_userdata($user_id);
+    }
 
-	/**
-	 * Check if we're dealing with a logged in user
-	 * 
-	 * @return boolean
-	 */
-	public function is_logged_in() {
-		return is_a($this->user, 'WP_User');
-	}
+    /**
+     * Check if we're dealing with a logged in user.
+     *
+     * @return bool
+     */
+    public function is_logged_in()
+    {
+        return is_a($this->user, 'WP_User');
+    }
 
-	/**
-	 * Check if current user is logged in and is a developer
-	 * 
-	 * @return boolean
-	 */
-	public function is_developer() {
-		return $this->user->exists() && in_array(self::DEVELOPER_ROLE_NAME, $this->user->roles);
-	}
+    /**
+     * Check if current user is logged in and is a developer.
+     *
+     * @return bool
+     */
+    public function is_developer()
+    {
+        return $this->user->exists() && in_array(self::DEVELOPER_ROLE_NAME, $this->user->roles);
+    }
 
-	/**
-	 * Save a tyk access token
-	 * Note that the actual tokens are not stored, just the name and id so we can manage them
-	 * 
-	 * @param  string $api_id ID of tyk API policy
-	 * @param  string $token_name User-given name of token
-	 * @param  string $hash Token hash
-	 * @return void
-	 */
-	public function save_access_token($api_id, $token_name, $hash) {
-		$data = array(
-			'api_id'     => sanitize_text_field($api_id),
-			'token_name' => sanitize_text_field($token_name),
-			'hash'       => sanitize_text_field($hash),
-			);
+    /**
+     * Save a tyk access token
+     * Note that the actual tokens are not stored, just the name and id so we can manage them.
+     *
+     * @param string $api_id     ID of tyk API policy
+     * @param string $token_name User-given name of token
+     * @param string $hash       Token hash
+     */
+    public function save_access_token($api_id, $token_name, $hash): void
+    {
+        $data = array(
+            'api_id'     => sanitize_text_field($api_id),
+            'token_name' => sanitize_text_field($token_name),
+            'hash'       => sanitize_text_field($hash),
+        );
 
-		// check if token already exists
-		$tokens = $this->get_access_tokens();
+        // check if token already exists
+        $tokens = $this->get_access_tokens();
 
-		$key = false;
-		if (count($tokens)) {
-			$ids = wp_list_pluck($tokens, 'hash');
-			$key = array_search($hash, $ids);
-		}
+        $key = false;
+        if (count($tokens)) {
+            $ids = wp_list_pluck($tokens, 'hash');
+            $key = array_search($hash, $ids);
+        }
 
-		// this is a new token
-		if ($key === false) {
-			$tokens[] = $data;
-		}
-		// this is an existing token
-		else {
-			$tokens[$key] = $data;
-		}
+        // this is a new token
+        if (false === $key) {
+            $tokens[] = $data;
+        }
+        // this is an existing token
+        else {
+            $tokens[$key] = $data;
+        }
 
-		// re-index array and update key in user meta storage
-		update_user_meta($this->user->ID, self::META_TYK_ACCESS_TOKENS_KEY, array_values($tokens));
-	}
+        // re-index array and update key in user meta storage
+        update_user_meta($this->user->ID, self::META_TYK_ACCESS_TOKENS_KEY, array_values($tokens));
+    }
 
-	/**
-	 * Get a single access token
-	 *
-	 * @throws OutOfBoundsException When token id is invalid
-	 * 
-	 * @param  string $hash
-	 * @return Tyk_Token
-	 */
-	public function get_access_token($hash) {
-		$tokens = $this->get_access_tokens();
-		foreach ($tokens as $token) {
-			if ($token['hash'] == $hash) {
-				return Tyk_Token::init($token, $this);
-			}
-		}
-		// if we get here, we didn't find the token
-		throw new OutOfBoundsException('Invalid token id');
-	}
+    /**
+     * Get a single access token.
+     *
+     * @param string $hash
+     *
+     * @return Tyk_Token
+     *
+     * @throws OutOfBoundsException When token id is invalid
+     */
+    public function get_access_token($hash)
+    {
+        $tokens = $this->get_access_tokens();
+        foreach ($tokens as $token) {
+            if ($token['hash'] == $hash) {
+                return Tyk_Token::init($token, $this);
+            }
+        }
 
-	/**
-	 * Get user's access tokens
-	 * 
-	 * @return array
-	 */
-	public function get_access_tokens() {
-		$tokens = get_user_meta($this->user->ID, self::META_TYK_ACCESS_TOKENS_KEY, true);
-		if (!is_array($tokens)) {
-			return array();
-		}
+        // if we get here, we didn't find the token
+        throw new OutOfBoundsException('Invalid token id');
+    }
 
-		// lambda to add an 'is_valid' attribute to each token
-		$map_is_valid = function ($token) {
-			return array_merge($token, array(
-				'is_valid' => $this->has_token($token['hash']),
-				));
-		};
+    /**
+     * Get user's access tokens.
+     *
+     * @return array
+     */
+    public function get_access_tokens()
+    {
+        $tokens = get_user_meta($this->user->ID, self::META_TYK_ACCESS_TOKENS_KEY, true);
+        if (!is_array($tokens)) {
+            return array();
+        }
 
-		return array_map($map_is_valid, $tokens);
-	}
+        // lambda to add an 'is_valid' attribute to each token
+        $map_is_valid = function ($token) {
+            return array_merge($token, array(
+                'is_valid' => $this->has_token($token['hash']),
+            ));
+        };
 
-	/**
-	 * Delete an access token by it's ID
-	 * 
-	 * @param  string $hash
-	 * @return void
-	 */
-	public function delete_access_token($hash) {
-		$tokens = $this->get_access_tokens();
-		$found = false;
-		foreach ($tokens as $i => $token) {
-			if ($token['hash'] == $hash) {
-				$found = true;
-				break;
-			}
-		}
-		if ($found === true) {
-			unset($tokens[$i]);
-			// re-index array update the dataset
-			update_user_meta($this->user->ID, self::META_TYK_ACCESS_TOKENS_KEY, array_values($tokens));
-		}
-	}
+        return array_map($map_is_valid, $tokens);
+    }
 
-	/**
-	 * Check if we already stored a tyk id for this developer
-	 * 
-	 * @return boolean
-	 */
-	public function has_tyk_id() {
-		$tyk_user_id = get_user_meta($this->user->ID, self::META_TYK_USER_ID_KEY, true);
-		return !empty($tyk_user_id);	
-	}
+    /**
+     * Delete an access token by it's ID.
+     *
+     * @param string $hash
+     */
+    public function delete_access_token($hash): void
+    {
+        $tokens = $this->get_access_tokens();
+        $found = false;
+        foreach ($tokens as $i => $token) {
+            if ($token['hash'] == $hash) {
+                $found = true;
 
-	/**
-	 * Set the user's tyk user id
-	 * 
-	 * @param string $id
-	 */
-	public function set_tyk_id($id) {
-		update_user_meta($this->user->ID, self::META_TYK_USER_ID_KEY, $id);
-	}
+                break;
+            }
+        }
+        if (true === $found) {
+            unset($tokens[$i]);
+            // re-index array update the dataset
+            update_user_meta($this->user->ID, self::META_TYK_ACCESS_TOKENS_KEY, array_values($tokens));
+        }
+    }
 
-	/**
-	 * Get the user's tyk user id
-	 * 
-	 * @return string
-	 */
-	public function get_tyk_id() {
-		return get_user_meta($this->user->ID, self::META_TYK_USER_ID_KEY, true);
-	}
+    /**
+     * Check if we already stored a tyk id for this developer.
+     *
+     * @return bool
+     */
+    public function has_tyk_id()
+    {
+        $tyk_user_id = get_user_meta($this->user->ID, self::META_TYK_USER_ID_KEY, true);
 
-	/**
-	 * Get tyk access token
-	 * 
-	 * @return array
-	 */
-	public function register_with_tyk() {
-		try {
-			$tyk = new Tyk_API();
-			$user_id = $tyk->post('/portal/developers', array(
-				'email' => $this->user->user_email,
-				));
-			$this->set_tyk_id($user_id);
-		}
-		catch (Exception $e) {
-			trigger_error(sprintf('Could not register user for API: %s', $e->getMessage()), E_USER_WARNING);
-		}
-	}
+        return !empty($tyk_user_id);
+    }
 
-	/**
-	 * Check if the user still has <token> according to tyk
-	 * 
-	 * @throws Exception If subscriptions info is missing in Tyk user data
-	 * 
-	 * @param string $hash
-	 * @return boolean
-	 */
-	private function has_token($hash) {
-		if (!isset($this->tyk_subscriptions) || !is_array($this->tyk_subscriptions)) {
-			$user_data = $this->fetch_from_tyk();
-			if (!isset($user_data->subscriptions)) {
-				throw new Exception('Missing policy subscriptions');
-			}
-			$this->tyk_subscriptions = array_flip((array) $user_data->subscriptions);
-		}
-		return isset($this->tyk_subscriptions[$hash]);
-	}
+    /**
+     * Set the user's tyk user id.
+     *
+     * @param string $id
+     */
+    public function set_tyk_id($id): void
+    {
+        update_user_meta($this->user->ID, self::META_TYK_USER_ID_KEY, $id);
+    }
 
-	/**
-	 * Fetch developer data from Tyk
-	 * 
-	 * @return stdClass
-	 */
-	public function fetch_from_tyk() {
-		try {
-			$tyk = new Tyk_API();
-			$developer = $tyk->get(sprintf('/portal/developers/%s', $this->get_tyk_id()));
-			if (!is_object($developer) || !isset($developer->id)) {
-				throw new Exception('Received invalid response');
-			}
-			return $developer;
-		}
-		catch (Exception $e) {
-			trigger_error(sprintf('Could not fetch developer from API: %s', $e->getMessage()), E_USER_WARNING);
-		}
-	}
+    /**
+     * Get the user's tyk user id.
+     *
+     * @return string
+     */
+    public function get_tyk_id()
+    {
+        return get_user_meta($this->user->ID, self::META_TYK_USER_ID_KEY, true);
+    }
+
+    /**
+     * Get tyk access token.
+     *
+     * @return array
+     */
+    public function register_with_tyk()
+    {
+        try {
+            $tyk = new Tyk_API();
+            $user_id = $tyk->post('/portal/developers', array(
+                'email' => $this->user->user_email,
+            ));
+            $this->set_tyk_id($user_id);
+        } catch (Exception $e) {
+            trigger_error(sprintf('Could not register user for API: %s', $e->getMessage()), E_USER_WARNING);
+        }
+    }
+
+    /**
+     * Check if the user still has <token> according to tyk.
+     *
+     * @param string $hash
+     *
+     * @return bool
+     *
+     * @throws Exception If subscriptions info is missing in Tyk user data
+     */
+    private function has_token($hash)
+    {
+        if (!isset($this->tyk_subscriptions) || !is_array($this->tyk_subscriptions)) {
+            $user_data = $this->fetch_from_tyk();
+            if (!isset($user_data->subscriptions)) {
+                throw new Exception('Missing policy subscriptions');
+            }
+            $this->tyk_subscriptions = array_flip((array) $user_data->subscriptions);
+        }
+
+        return isset($this->tyk_subscriptions[$hash]);
+    }
+
+    /**
+     * Fetch developer data from Tyk.
+     *
+     * @return stdClass
+     */
+    public function fetch_from_tyk()
+    {
+        try {
+            $tyk = new Tyk_API();
+            $developer = $tyk->get(sprintf('/portal/developers/%s', $this->get_tyk_id()));
+            if (!is_object($developer) || !isset($developer->id)) {
+                throw new Exception('Received invalid response');
+            }
+
+            return $developer;
+        } catch (Exception $e) {
+            trigger_error(sprintf('Could not fetch developer from API: %s', $e->getMessage()), E_USER_WARNING);
+        }
+    }
 }

--- a/classes/token.php
+++ b/classes/token.php
@@ -255,35 +255,17 @@ class Tyk_Token
 	 *
 	 * @throws InvalidArgumentException When this class doesn't have all the data it needs
 	 * @throws UnexpectedValueException When API does not respond as expected
-	 * 
-	 * @return boolean True when successful
+	 *
 	 */
 	public function revoke() {
-		if (!is_string($this->policy) || !is_string($this->hash) || !is_a($this->user, 'Tyk_Portal_User')) {
+		if (!is_string($this->hash) || !is_a($this->user, 'Tyk_Portal_User')) {
 			throw new InvalidArgumentException('Missing token information');
 		}
-
-		try {
-			$response = $this->api->delete(sprintf('/portal/developers/key/%s/%s/%s',
-				$this->policy,
-				$this->hash,
-				$this->user->get_tyk_id()
-				));
-			if (is_object($response) && isset($response->Status) && $response->Status == 'OK') {
-				if (Tyk_Dev_Portal::is_hybrid()) {
-					$response = $this->gateway->delete(sprintf('/keys/%s?hashed=1', $this->hash));
-					if (is_object($response) && isset($response->status) && $response->status == 'ok') {
-						return true;
-					}
-					else {
-						throw new Exception('Received invalid response from Gateway');
-					}
-				}
-				return true;
-			}
-			else {
-				throw new Exception('Received invalid response from API');
-			}
+        try {
+            $this->api->delete(sprintf('/api/apis/%s/keys/%s',
+                null,
+                $this->hash
+            ));
 		}
 		catch (Exception $e) {
 			throw new UnexpectedValueException($e->getMessage());

--- a/classes/token.php
+++ b/classes/token.php
@@ -1,380 +1,402 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * This class represents a key/token request for a Tyk API policy
+ * This class represents a key/token request for a Tyk API policy.
  *
  * This class is a bit of a mess. It represents a key request and a token.
  * Maybe we should refactor it into two classes that each serve one purpose.
  */
 class Tyk_Token
 {
-	/**
-	 * Key request ID
-	 * @var string
-	 */
-	protected $id;
+    /**
+     * Key request ID.
+     *
+     * @var string
+     */
+    protected $id;
 
-	/**
-	 * Key/access token
-	 * This is the unhashed access token we show to user but do not save
-	 * @var string
-	 */
-	protected $key;
+    /**
+     * Key/access token
+     * This is the unhashed access token we show to user but do not save.
+     *
+     * @var string
+     */
+    protected $key;
 
-	/**
-	 * Key/access token hash
-	 * This is the hashed access token we save
-	 * @var string
-	 */
-	protected $hash;
+    /**
+     * Key/access token hash
+     * This is the hashed access token we save.
+     *
+     * @var string
+     */
+    protected $hash;
 
-	/**
-	 * API/policy id
-	 * @var string
-	 */
-	protected $policy;
+    /**
+     * API/policy id.
+     *
+     * @var string
+     */
+    protected $policy;
 
-	/**
-	 * Tyk API interaction handler
-	 * @var Tyk_API
-	 */
-	protected $api;
+    /**
+     * Tyk API interaction handler.
+     *
+     * @var Tyk_API
+     */
+    protected $api;
 
-	/**
-	 * Tyk Gateway interaction handler
-	 * @var Tyk_Gateway
-	 */
-	protected $gateway;
+    /**
+     * Tyk Gateway interaction handler.
+     *
+     * @var Tyk_Gateway
+     */
+    protected $gateway;
 
-	/**
-	 * Tyk portal user
-	 * @var Tyk_Portal_User
-	 */
-	protected $user;
+    /**
+     * Tyk portal user.
+     *
+     * @var Tyk_Portal_User
+     */
+    protected $user;
 
-	/**
-	 * Setup the class
-	 *
-	 * @param Portal_User $user
-	 * @param string $policy optional, not required for all actions
-	 */
-	public function __construct(Tyk_Portal_User $user, $policy = null) {
-		$this->api = new Tyk_API;
-		$this->gateway = new Tyk_Gateway;
-		$this->user = $user;
-		if (!is_null($policy)) {
-			$this->policy = $policy;
-		}
-	}
+    /**
+     * Setup the class.
+     *
+     * @param Portal_User $user
+     * @param string      $policy optional, not required for all actions
+     */
+    public function __construct(Tyk_Portal_User $user, $policy = null)
+    {
+        $this->api = new Tyk_API();
+        $this->gateway = new Tyk_Gateway();
+        $this->user = $user;
+        if (!is_null($policy)) {
+            $this->policy = $policy;
+        }
+    }
 
-	/**
-	 * Set an existing token
-	 * 
-	 * @param array $token
-	 * @param Portal_User $user
-	 * @return Tyk_Token
-	 */
-	public static function init(array $token, Tyk_Portal_User $user) {
-		if (isset($token['api_id']) && isset($token['hash'])) {
-			$instance = new Tyk_Token($user, $token['api_id']);
-			$instance->set_hash($token['hash']);
-			$instance->set_name($token['token_name']);
-			return $instance;
-		}
-		else {
-			throw new InvalidArgumentException('Invalid token specified');
-		}
-	}
+    /**
+     * Set an existing token.
+     *
+     * @param Portal_User $user
+     *
+     * @return Tyk_Token
+     */
+    public static function init(array $token, Tyk_Portal_User $user)
+    {
+        if (isset($token['api_id'], $token['hash'])) {
+            $instance = new Tyk_Token($user, $token['api_id']);
+            $instance->set_hash($token['hash']);
+            $instance->set_name($token['token_name']);
 
-	/**
-	 * Setup token from the key
-	 * 
-	 * @param string $key
-	 * @param Tyk_Portal_User $user
-	 * @return Tyk_Token
-	 */
-	public static function init_from_key($key, Tyk_Portal_User $user) {
-		$token = new Tyk_Token($user);
-		$token->set_key($key);
-		return $token;
+            return $instance;
+        }
 
-	}
+        throw new InvalidArgumentException('Invalid token specified');
+    }
 
-	/**
-	 * Get the key request id (not the actual token)
-	 * 
-	 * @return string
-	 */
-	public function get_id() {
-		return $this->id;
-	}
+    /**
+     * Setup token from the key.
+     *
+     * @param string $key
+     *
+     * @return Tyk_Token
+     */
+    public static function init_from_key($key, Tyk_Portal_User $user)
+    {
+        $token = new Tyk_Token($user);
+        $token->set_key($key);
 
-	/**
-	 * Set the key request id
-	 * You shouldn't use this, this is for testing
-	 * 
-	 * @return string
-	 */
-	public function set_id($id) {
-		$this->id = $id;
-	}
+        return $token;
+    }
 
-	/**
-	 * Get the key/access token
-	 * 
-	 * @return string
-	 */
-	public function get_key() {
-		return $this->key;
-	}
+    /**
+     * Get the key request id (not the actual token).
+     *
+     * @return string
+     */
+    public function get_id()
+    {
+        return $this->id;
+    }
 
-	/**
-	 * Set the unhashed key
-	 * 
-	 * @param string $key
-	 */
-	public function set_key($key) {
-		$this->key = $key;
-	}
+    /**
+     * Set the key request id
+     * You shouldn't use this, this is for testing.
+     *
+     * @param mixed $id
+     *
+     * @return string
+     */
+    public function set_id($id)
+    {
+        $this->id = $id;
+    }
 
-	/**
-	 * Set the hashed token
-	 * 
-	 * @param string $hash
-	 */
-	public function set_hash($hash) {
-		$this->hash = $hash;
-	}
+    /**
+     * Get the key/access token.
+     *
+     * @return string
+     */
+    public function get_key()
+    {
+        return $this->key;
+    }
 
-	/**
-	 * Get the hashed token
-	 * 
-	 * @return string
-	 */
-	public function get_hash() {
-		return $this->hash;
-	}
+    /**
+     * Set the unhashed key.
+     *
+     * @param string $key
+     */
+    public function set_key($key): void
+    {
+        $this->key = $key;
+    }
 
-	/**
-	 * Set the name
-	 * 
-	 * @param string $name
-	 */
-	public function set_name($name) {
-		$this->name = $name;
-	}
+    /**
+     * Set the hashed token.
+     *
+     * @param string $hash
+     */
+    public function set_hash($hash): void
+    {
+        $this->hash = $hash;
+    }
 
-	/**
-	 * Get the name
-	 * Note: the name isn't always set, only when token is setup with self::init()
-	 * 
-	 * @return string
-	 */
-	public function get_name() {
-		return $this->name;
-	}
+    /**
+     * Get the hashed token.
+     *
+     * @return string
+     */
+    public function get_hash()
+    {
+        return $this->hash;
+    }
 
-	/**
-	 * Get the api policy ID
-	 * 
-	 * @return string
-	 */
-	public function get_policy() {
-		return $this->policy;
-	}
+    /**
+     * Set the name.
+     *
+     * @param string $name
+     */
+    public function set_name($name): void
+    {
+        $this->name = $name;
+    }
 
-	/**
-	 * Make a key request for a tyk api plan/policy
-	 *
-	 * @throws UnexpectedValueException When we get an invalid response from API
-	 * 
-	 * @return string
-	 */
-	public function request() {
-		$request_id = $this->api->post('/portal/requests', array(
-			'by_user' => $this->user->get_tyk_id(),
-			'for_plan' => $this->policy,
-			// as of Tyk Dashboard v1.8 this always needs to be set to false
-			// otherwise the subsequent approval call fails because the request
-			// is already considered as approved.
-			'approved' => false,
-			// this is a bit absurd but tyk api doesn't set this by itself
-			'date_created' => date('c'),
-			'version' => 'v2',
-			));
+    /**
+     * Get the name
+     * Note: the name isn't always set, only when token is setup with self::init().
+     *
+     * @return string
+     */
+    public function get_name()
+    {
+        return $this->name;
+    }
 
-		// save key request id
-		if (is_string($request_id)) {
-			$this->id = $request_id;
-		}
-		else {
-			throw new UnexpectedValueException('Received an invalid response for key request');
-		}
-	}
+    /**
+     * Get the api policy ID.
+     *
+     * @return string
+     */
+    public function get_policy()
+    {
+        return $this->policy;
+    }
 
-	/**
-	 * Approve a key request
-	 * 
-	 * Unfortunately, tyk api doesn't support making and approving a key
-	 * request in the same request, so this method must be invoked after
-	 * issuing {@link this::request()}.
-	 *
-	 * @throws InvalidArgumentException When the key request ID is missing
-	 * @throws UnexpectedValueException When we don't get a token back from API
-	 *
-	 * @return void
-	 */
-	public function approve() {
-		if (!is_string($this->id) || empty($this->id)) {
-			throw new InvalidArgumentException('Invalid key request');
-		}
+    /**
+     * Make a key request for a tyk api plan/policy.
+     *
+     * @return string
+     *
+     * @throws UnexpectedValueException When we get an invalid response from API
+     */
+    public function request()
+    {
+        $request_id = $this->api->post('/portal/requests', array(
+            'by_user' => $this->user->get_tyk_id(),
+            'for_plan' => $this->policy,
+            // as of Tyk Dashboard v1.8 this always needs to be set to false
+            // otherwise the subsequent approval call fails because the request
+            // is already considered as approved.
+            'approved' => false,
+            // this is a bit absurd but tyk api doesn't set this by itself
+            'date_created' => date('c'),
+            'version' => 'v2',
+        ));
 
-		try {
-			$token = $this->api->put('/portal/requests/approve', $this->id);
-			$developer = $this->user->fetch_from_tyk();
-			if (is_object($token) && isset($token->RawKey) && !empty($token->RawKey)) {
-				$this->key = $token->RawKey;
+        // save key request id
+        if (is_string($request_id)) {
+            $this->id = $request_id;
+        } else {
+            throw new UnexpectedValueException('Received an invalid response for key request');
+        }
+    }
 
-				if (is_object($developer) && isset($developer->subscriptions)) {
-					if (isset($developer->subscriptions->{$this->policy})) {
-						$this->hash = $developer->subscriptions->{$this->policy};
-					}
-				}
-			}
-			else {
-				throw new Exception('Could not approve token request');
-			}
-		}
-		catch (Exception $e) {
-			throw new UnexpectedValueException($e->getMessage());
-		}
-	}
+    /**
+     * Approve a key request.
+     *
+     * Unfortunately, tyk api doesn't support making and approving a key
+     * request in the same request, so this method must be invoked after
+     * issuing {@link this::request()}.
+     *
+     * @throws InvalidArgumentException When the key request ID is missing
+     * @throws UnexpectedValueException When we don't get a token back from API
+     */
+    public function approve(): void
+    {
+        if (!is_string($this->id) || empty($this->id)) {
+            throw new InvalidArgumentException('Invalid key request');
+        }
 
-	/**
-	 * Revoke (delete!) a token
-	 *
-	 * @throws InvalidArgumentException When this class doesn't have all the data it needs
-	 * @throws UnexpectedValueException When API does not respond as expected
-	 *
-	 */
-	public function revoke() {
-		if (!is_string($this->hash) || !is_a($this->user, 'Tyk_Portal_User')) {
-			throw new InvalidArgumentException('Missing token information');
-		}
         try {
-            $this->api->delete(sprintf('/api/apis/%s/keys/%s',
-                null,
-                $this->hash
-            ));
-		}
-		catch (Exception $e) {
-			throw new UnexpectedValueException($e->getMessage());
-		}
-	}
+            $token = $this->api->put('/portal/requests/approve', $this->id);
+            $developer = $this->user->fetch_from_tyk();
+            if (is_object($token) && isset($token->RawKey) && !empty($token->RawKey)) {
+                $this->key = $token->RawKey;
 
-	/**
-	 * Get usage quota of this token
-	 * Requires the unhashed key of the token, unfortunately.
-	 *
-	 * @throws InvalidArgumentException When the key isn't set
-	 * @throws UnexpectedValueException When API does not respond as expected
-	 * 
-	 * @return object Usage quota
-	 */
-	public function get_usage_quota() {
-		if (!is_string($this->key)) {
-			throw new InvalidArgumentException('Missing token key');
-		}
-		if (strlen($this->key) === 56) {
-			$this->key = TYK_ORG_ID.$this->key;
-			
-		}
-		try {
-			/**
-			 * Hybrid Tyk
+                if (is_object($developer) && isset($developer->subscriptions)) {
+                    if (isset($developer->subscriptions->{$this->policy})) {
+                        $this->hash = $developer->subscriptions->{$this->policy};
+                    }
+                }
+            } else {
+                throw new Exception('Could not approve token request');
+            }
+        } catch (Exception $e) {
+            throw new UnexpectedValueException($e->getMessage());
+        }
+    }
+
+    /**
+     * Revoke (delete!) a token.
+     *
+     * @throws InvalidArgumentException When this class doesn't have all the data it needs
+     * @throws UnexpectedValueException When API does not respond as expected
+     */
+    public function revoke(): void
+    {
+        if (!is_string($this->hash) || !is_a($this->user, 'Tyk_Portal_User')) {
+            throw new InvalidArgumentException('Missing token information');
+        }
+
+        try {
+            $this->api->delete(sprintf(
+                '/api/apis/%s/keys/%s',
+                null,
+                $this->hash,
+            ));
+        } catch (Exception $e) {
+            throw new UnexpectedValueException($e->getMessage());
+        }
+    }
+
+    /**
+     * Get usage quota of this token
+     * Requires the unhashed key of the token, unfortunately.
+     *
+     * @return object Usage quota
+     *
+     * @throws InvalidArgumentException When the key isn't set
+     * @throws UnexpectedValueException When API does not respond as expected
+     */
+    public function get_usage_quota()
+    {
+        if (!is_string($this->key)) {
+            throw new InvalidArgumentException('Missing token key');
+        }
+        if (56 === strlen($this->key)) {
+            $this->key = TYK_ORG_ID . $this->key;
+        }
+
+        try {
+            /*
+             * Hybrid Tyk
              * Get usage quota from gateways, as this info isn't synced back to cloud
              */
             if (Tyk_Dev_Portal::is_hybrid()) {
                 $response = $this->gateway->get(sprintf('/keys/%s', $this->key));
                 if (is_object($response) && isset($response->quota_remaining)) {
-                    return (object)array(
+                    return (object) array(
                         'quota_remaining' => $response->quota_remaining,
-                        'quota_max' => $response->quota_max
+                        'quota_max' => $response->quota_max,
                     );
-                } else {
-                    throw new Exception('Received invalid response from Gateway');
                 }
-            } /**
-			 * Cloud and on-premise Tyk
-			 * Get usage quota from API
-			 */
-			else {
-				// first: we need an api id on which to request the tokens
-				// sounds weird I know, here's the explanation: https://community.tyk.io/t/several-questions/1041/3
-				$apiManager = new Tyk_API_Manager;
-				$apis = $apiManager->available_apis();
-				if (is_array($apis)) {
-					$firstApi = array_shift($apis);
-					$response = $this->api->get(sprintf('/apis/%s/keys/%s',
-						$firstApi->api_definition->api_id,
-						$this->key
-					));
-				}
-				if (is_object($response) && isset($response->data)) {
-					return $response->data;
-				}
-				else {
-					throw new Exception('Received invalid response from API');
-				}
-			}
-		}
-		catch (Exception $e) {
-			throw new UnexpectedValueException($e->getMessage());
-		}
-	}
 
-	/**
-	 * Get usage stats for this token
-	 *
-	 * @throws InvalidArgumentException When the hash isn't set
-	 * @throws UnexpectedValueException When API does not respond as expected
-	 *
-	 * @param string $from_date From this date forward
-	 * @param string $to_date To this date
-	 * @return object Usage data
-	 */
-	public function get_usage($from_date = null, $to_date = null) {
-		if (!is_string($this->hash)) {
-			throw new InvalidArgumentException('Missing token hash');
-		}
+                throw new Exception('Received invalid response from Gateway');
+            } /*
+             * Cloud and on-premise Tyk
+             * Get usage quota from API
+             */
+            else {
+                // first: we need an api id on which to request the tokens
+                // sounds weird I know, here's the explanation: https://community.tyk.io/t/several-questions/1041/3
+                $apiManager = new Tyk_API_Manager();
+                $apis = $apiManager->available_apis();
+                if (is_array($apis)) {
+                    $firstApi = array_shift($apis);
+                    $response = $this->api->get(sprintf(
+                        '/apis/%s/keys/%s',
+                        $firstApi->api_definition->api_id,
+                        $this->key,
+                    ));
+                }
+                if (is_object($response) && isset($response->data)) {
+                    return $response->data;
+                }
 
-		// use from_date or today-1 month
-		$from = is_null($from_date)
-			? strtotime('-1 week')
-			: strtotime($from_date);
-		// use to_date or <now>
-		$to = is_null($to_date)
-			? time()
-			: strtotime($to_date);
+                throw new Exception('Received invalid response from API');
+            }
+        } catch (Exception $e) {
+            throw new UnexpectedValueException($e->getMessage());
+        }
+    }
 
-		try {
-			$response = $this->api->get(sprintf('/activity/keys/%s/%s/%s',
-				$this->hash,
-				date('j/n/Y', $from),
-				date('j/n/Y', $to)
-			), array(
-				'res' => 'day',
-				'p' => -1
-			));
-			if (is_object($response) && property_exists($response, 'data')) {
-				return $response->data;
-			}
-			else {
-				throw new Exception('Received invalid response from API');
-			}
-		}
-		catch (Exception $e) {
-			throw new UnexpectedValueException($e->getMessage());
-		}
-	}
+    /**
+     * Get usage stats for this token.
+     *
+     * @param string $from_date From this date forward
+     * @param string $to_date   To this date
+     *
+     * @return object Usage data
+     *
+     * @throws InvalidArgumentException When the hash isn't set
+     * @throws UnexpectedValueException When API does not respond as expected
+     */
+    public function get_usage($from_date = null, $to_date = null)
+    {
+        if (!is_string($this->hash)) {
+            throw new InvalidArgumentException('Missing token hash');
+        }
+
+        // use from_date or today-1 month
+        $from = is_null($from_date)
+            ? strtotime('-1 week')
+            : strtotime($from_date);
+        // use to_date or <now>
+        $to = is_null($to_date)
+            ? time()
+            : strtotime($to_date);
+
+        try {
+            $response = $this->api->get(sprintf(
+                '/activity/keys/%s/%s/%s',
+                $this->hash,
+                date('j/n/Y', $from),
+                date('j/n/Y', $to),
+            ), array(
+                'res' => 'day',
+                'p' => -1,
+            ));
+            if (is_object($response) && property_exists($response, 'data')) {
+                return $response->data;
+            }
+
+            throw new Exception('Received invalid response from API');
+        } catch (Exception $e) {
+            throw new UnexpectedValueException($e->getMessage());
+        }
+    }
 }

--- a/classes/tyk_api.php
+++ b/classes/tyk_api.php
@@ -1,144 +1,147 @@
 <?php
+
+declare(strict_types=1);
 /**
- * Tyk API adapter
- *
- * @package Tyk_Dev_Portal\Tyk_API
+ * Tyk API adapter.
  */
 
 /**
- * Class to handle interaction with Tyk API
+ * Class to handle interaction with Tyk API.
  */
 class Tyk_API extends Tyk_Interaction
 {
-	/**
-	 * Send a post request to Tyk API
-	 * 
-	 * @param string $path Path to endpoint
-	 * @param array $body
-	 *
-	 * @throws Exception When API sends invalid response
-	 * @throws Exception When API reports a NOT OK status
-	 * 
-	 * @return array
-	 */
-	public function post($path, array $body) {
-		$api_response = wp_remote_post($this->get_url_for_path($path), array(
-			'headers' => array(
-				'Authorization' => TYK_API_KEY,
-			),
-			'body' => json_encode($body),
-			));
+    /**
+     * Send a post request to Tyk API.
+     *
+     * @param string $path Path to endpoint
+     *
+     * @return array
+     *
+     * @throws Exception When API sends invalid response
+     * @throws Exception When API reports a NOT OK status
+     */
+    public function post($path, array $body)
+    {
+        $api_response = wp_remote_post($this->get_url_for_path($path), array(
+            'headers' => array(
+                'Authorization' => TYK_API_KEY,
+            ),
+            'body' => json_encode($body),
+        ));
 
-		// analyse response
-		$response = $this->parse_response($api_response);
-		if (is_object($response) && isset($response->Status) && isset($response->Message)) {
-			if ($response->Status == 'OK') {
-				return $response->Message;
-			}
-			else {
-				throw new Exception($response->Message);
-			}
-		}
-		else {
-			throw new Exception('Received invalid response from API');
-		}
-	}
+        // analyse response
+        $response = $this->parse_response($api_response);
+        if (is_object($response) && isset($response->Status, $response->Message)) {
+            if ('OK' == $response->Status) {
+                return $response->Message;
+            }
 
-	/**
-	 * Send a get request to Tyk API
-	 * 
-	 * @param string $path
-	 * @param array $args  Query string args
-	 *
-	 * @throws Exception When API sends invalid response
-	 * 
-	 * @return array
-	 */
-	public function get($path, array $args = null) {
-		$api_response = wp_remote_get($this->get_url_for_path($path, $args), array(
-			'headers' => array(
-				'Authorization' => TYK_API_KEY,
-			)));
+            throw new Exception($response->Message);
+        } else {
+            throw new Exception('Received invalid response from API');
+        }
+    }
 
-		$response = $this->parse_response($api_response);
-		if (is_object($response)) {
-			return $response;
-		}
-		else {
-			throw new Exception('Received invalid response from API');
-		}
-	}
+    /**
+     * Send a get request to Tyk API.
+     *
+     * @param string $path
+     * @param array  $args Query string args
+     *
+     * @return array
+     *
+     * @throws Exception When API sends invalid response
+     */
+    public function get($path, ?array $args = null)
+    {
+        $api_response = wp_remote_get($this->get_url_for_path($path, $args), array(
+            'headers' => array(
+                'Authorization' => TYK_API_KEY,
+            )));
 
-	/**
-	 * Send a put request to Tyk API
-	 * 
-	 * @param string $path
-	 * @param string $location
-	 *
-	 * @throws Exception When API sends invalid response
-	 * 
-	 * @return array
-	 */
-	public function put($path, $location) {
-		$base_url = $this->get_url_for_path($path);
-		$url = $base_url . '/' . $location;
+        $response = $this->parse_response($api_response);
+        if (is_object($response)) {
+            return $response;
+        }
 
-		$api_response = wp_remote_request($url, array(
-			'method' => 'PUT',
-			'headers' => array(
-				'Authorization' => TYK_API_KEY,
-			)));
-		$response = $this->parse_response($api_response);
-		if (is_object($response)) {
-			return $response;
-		}
-		else {
-			throw new Exception('Received invalid response from API');
-		}
-	}
+        throw new Exception('Received invalid response from API');
+    }
 
-	/**
-	 * Send a delete request to Tyk API
-	 * 
-	 * @throws Exception When API sends invalid response
-	 * 
-	 * @param string $path
-	 * @return stdClass
-	 */
-	public function delete($path) {
+    /**
+     * Send a put request to Tyk API.
+     *
+     * @param string $path
+     * @param string $location
+     *
+     * @return array
+     *
+     * @throws Exception When API sends invalid response
+     */
+    public function put($path, $location)
+    {
+        $base_url = $this->get_url_for_path($path);
+        $url = $base_url . '/' . $location;
+
+        $api_response = wp_remote_request($url, array(
+            'method' => 'PUT',
+            'headers' => array(
+                'Authorization' => TYK_API_KEY,
+            )));
+        $response = $this->parse_response($api_response);
+        if (is_object($response)) {
+            return $response;
+        }
+
+        throw new Exception('Received invalid response from API');
+    }
+
+    /**
+     * Send a delete request to Tyk API.
+     *
+     * @param string $path
+     *
+     * @return stdClass
+     *
+     * @throws Exception When API sends invalid response
+     */
+    public function delete($path)
+    {
         $url = $this->get_url_for_path($path);
         $api_response = wp_remote_request($url, array(
             'method' => 'DELETE',
             'headers' => array(
                 'Authorization' => TYK_API_KEY,
-            )
+            ),
         ));
 
         $response = $this->parse_response($api_response);
         if (is_object($response)) {
             return $response;
         }
-        else {
-            throw new Exception('Received invalid response from API');
-        }
+
+        throw new Exception('Received invalid response from API');
     }
 
-	/**
-	 * Get absolute url to api endpoint for a path
-	 * 
+    /**
+     * Get absolute url to api endpoint for a path.
+     *
      * @param string $path
-	 * @return string
-	 */
-	protected function get_url_for_path($path, array $args = null) {
-		// build query string out of args if they're set
-		$qs = '';
-		if (is_array($args)) {
-			$qs = '?' . http_build_query($args);
+     *
+     * @return string
+     */
+    protected function get_url_for_path($path, ?array $args = null)
+    {
+        // build query string out of args if they're set
+        $qs = '';
+        if (is_array($args)) {
+            $qs = '?' . http_build_query($args);
         }
-		return sprintf('%s/%s%s', 
-			rtrim(TYK_API_ENDPOINT, '/'), 
-			ltrim($path, '/'),
-			$qs
-			);
-	}
+
+        return sprintf(
+            '%s/%s%s',
+            rtrim(TYK_API_ENDPOINT, '/'),
+            ltrim($path, '/'),
+            $qs,
+        );
+    }
 }

--- a/classes/tyk_api.php
+++ b/classes/tyk_api.php
@@ -106,22 +106,22 @@ class Tyk_API extends Tyk_Interaction
 	 * @return stdClass
 	 */
 	public function delete($path) {
-		$url = $this->get_url_for_path($path);
+        $url = $this->get_url_for_path($path);
+        $api_response = wp_remote_request($url, array(
+            'method' => 'DELETE',
+            'headers' => array(
+                'Authorization' => TYK_API_KEY,
+            )
+        ));
 
-		$api_response = wp_remote_request($url, array(
-			'method' => 'DELETE',
-			'headers' => array(
-				'Authorization' => TYK_API_KEY,
-			)));
-
-		$response = $this->parse_response($api_response);
-		if (is_object($response)) {
-			return $response;
-		}
-		else {
-			throw new Exception('Received invalid response from API');
-		}	
-	}
+        $response = $this->parse_response($api_response);
+        if (is_object($response)) {
+            return $response;
+        }
+        else {
+            throw new Exception('Received invalid response from API');
+        }
+    }
 
 	/**
 	 * Get absolute url to api endpoint for a path

--- a/classes/tyk_gateway.php
+++ b/classes/tyk_gateway.php
@@ -1,85 +1,90 @@
 <?php
+
+declare(strict_types=1);
 /**
- * Tyk API adapter
- *
- * @package Tyk_Dev_Portal\Tyk_Gateway
+ * Tyk API adapter.
  */
 
 /**
  * Class to handle interaction with Tyk gateway
- * Note: if you have multiple gateways, TYK_GATEWAY_URL should point to your load balancer
+ * Note: if you have multiple gateways, TYK_GATEWAY_URL should point to your load balancer.
  */
 class Tyk_Gateway extends Tyk_Interaction
 {
-	/**
-	 * Send a get request to Tyk gateway
-	 * 
-	 * @param string $path
-	 * @param array $args  Query string args
-	 *
-	 * @throws Exception When API sends invalid response
-	 * 
-	 * @return array
-	 */
-	public function get($path, array $args = null) {
-		// if gateway credentials are configured, setup 
-		$api_response = wp_remote_get($this->get_url_for_path($path, $args), array(
-			'headers' => array(
-				'x-tyk-authorization' => TYK_GATEWAY_SECRET
-			),
-		));
+    /**
+     * Send a get request to Tyk gateway.
+     *
+     * @param string $path
+     * @param array  $args Query string args
+     *
+     * @return array
+     *
+     * @throws Exception When API sends invalid response
+     */
+    public function get($path, ?array $args = null)
+    {
+        // if gateway credentials are configured, setup
+        $api_response = wp_remote_get($this->get_url_for_path($path, $args), array(
+            'headers' => array(
+                'x-tyk-authorization' => TYK_GATEWAY_SECRET,
+            ),
+        ));
 
-		$response = $this->parse_response($api_response);
-		if (is_object($response)) {
-			return $response;
-		}
-		else {
-			throw new Exception('Received invalid response from Gateway');
-		}
-	}
+        $response = $this->parse_response($api_response);
+        if (is_object($response)) {
+            return $response;
+        }
 
-	/**
-	 * Send a delete request to Tyk gateway
-	 * 
-	 * @throws Exception when the gateway sends an invalid response
-	 * 
-	 * @param string $path
-	 * @return stdClass
-	 */
-	public function delete($path) {
-		$url = $this->get_url_for_path($path);
+        throw new Exception('Received invalid response from Gateway');
+    }
 
-		$api_response = wp_remote_request($url, array(
-			'method' => 'DELETE',
-			'headers' => array(
-				'x-tyk-authorization' => TYK_GATEWAY_SECRET
-			)));
+    /**
+     * Send a delete request to Tyk gateway.
+     *
+     * @param string $path
+     *
+     * @return stdClass
+     *
+     * @throws Exception when the gateway sends an invalid response
+     */
+    public function delete($path)
+    {
+        $url = $this->get_url_for_path($path);
 
-		$response = $this->parse_response($api_response);
-		if (is_object($response)) {
-			return $response;
-		}
-		else {
-			throw new Exception('Received invalid response from API');
-		}
-	}
+        $api_response = wp_remote_request($url, array(
+            'method' => 'DELETE',
+            'headers' => array(
+                'x-tyk-authorization' => TYK_GATEWAY_SECRET,
+            )));
 
-	/**
-	 * Get absolute url to api endpoint for a path
-	 * 
-	 * @param string $path
-	 * @return string
-	 */
-	protected function get_url_for_path($path, array $args = null) {
-		// build query string out of args if they're set
-		$qs = '';
-		if (is_array($args)) {
-			$qs = '?' . http_build_query($args);
-		}
-		return sprintf('%s/%s%s', 
-			rtrim(TYK_GATEWAY_URL, '/'), 
-			ltrim($path, '/'),
-			$qs
-			);
-	}
+        $response = $this->parse_response($api_response);
+        if (is_object($response)) {
+            return $response;
+        }
+
+        throw new Exception('Received invalid response from API');
+    }
+
+    /**
+     * Get absolute url to api endpoint for a path.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    protected function get_url_for_path($path, ?array $args = null)
+    {
+        // build query string out of args if they're set
+        $qs = '';
+        if (is_array($args)) {
+            $qs = '?' . http_build_query($args);
+        }
+
+        return sprintf(
+            '%s/%s%s',
+            rtrim(TYK_GATEWAY_URL, '/'),
+            ltrim($path, '/'),
+            $qs,
+        );
+    }
 }

--- a/classes/tyk_interaction.php
+++ b/classes/tyk_interaction.php
@@ -1,63 +1,64 @@
 <?php
+
+declare(strict_types=1);
 /**
- * Tyk API adapter
- *
- * @package Tyk_Dev_Portal\Tyk_Interaction
+ * Tyk API adapter.
  */
 
 /**
- * Abstraction for classes interacting with Tyk
+ * Abstraction for classes interacting with Tyk.
  */
 abstract class Tyk_Interaction
 {
-	/**
-	 * Abstraction must define how an url is obtained for a path
-	 * 
-	 * @param string $path
-	 * @param array|null $args
-	 * @return string
-	 */
-	abstract protected function get_url_for_path($path, array $args = null);
+    /**
+     * Abstraction must define how an url is obtained for a path.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    abstract protected function get_url_for_path($path, ?array $args = null);
 
-	/**
-	 * Parse and analyse response
-	 * 
-	 * @param mixed $api_response
-	 *
-	 * @throws Exception When API sends a non-200 response code
-	 * 
-	 * @return mixed
-	 */
-	protected function parse_response($api_response) {
-		// parse errors
-		if ($api_response instanceof WP_Error) {
-			$error_list = array();
-			foreach ($api_response->errors as $name => $errors) {
-				$error_list[] = is_array($errors)
-					? join('. ', $errors)
-					: $errors;
-			}
-			if (count($error_list) > 0) {
-				throw new Exception(sprintf('API error: %s', join('. ', $error_list)));
-			}
-			else {
-				throw new Exception('An unknown error occured when connecting to API');
-			}
-		}
-		// parse response
-		else {
-			$response = json_decode(wp_remote_retrieve_body($api_response));
-			$http_code = wp_remote_retrieve_response_code($api_response);
-			$message = wp_remote_retrieve_response_message($api_response);
-			if ($http_code != 200) {
-				// see if we have more information
-				if (is_object($response) && isset($response->Message)) {
-					$message .= sprintf(': %s', $response->Message);
-				}
-				throw new Exception($message);
-			}
-		}
+    /**
+     * Parse and analyse response.
+     *
+     * @param mixed $api_response
+     *
+     * @return mixed
+     *
+     * @throws Exception When API sends a non-200 response code
+     */
+    protected function parse_response($api_response)
+    {
+        // parse errors
+        if ($api_response instanceof WP_Error) {
+            $error_list = array();
+            foreach ($api_response->errors as $name => $errors) {
+                $error_list[] = is_array($errors)
+                    ? join('. ', $errors)
+                    : $errors;
+            }
+            if (count($error_list) > 0) {
+                throw new Exception(sprintf('API error: %s', join('. ', $error_list)));
+            }
 
-		return $response;
-	}
+            throw new Exception('An unknown error occured when connecting to API');
+        }
+        // parse response
+        else {
+            $response = json_decode(wp_remote_retrieve_body($api_response));
+            $http_code = wp_remote_retrieve_response_code($api_response);
+            $message = wp_remote_retrieve_response_message($api_response);
+            if (200 != $http_code) {
+                // see if we have more information
+                if (is_object($response) && isset($response->Message)) {
+                    $message .= sprintf(': %s', $response->Message);
+                }
+
+                throw new Exception($message);
+            }
+        }
+
+        return $response;
+    }
 }

--- a/template_tags.php
+++ b/template_tags.php
@@ -1,20 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Get the developer dashboard page
- * Returns the html code or an error message when user is not logged in
- * 
+ * Returns the html code or an error message when user is not logged in.
+ *
  * @return string
  */
-function tyk_dev_portal_dashboard() {
-	$user = new Tyk_Portal_User;
-	if ($user->is_logged_in()) {
-		ob_start();
-		include_once TYK_DEV_PORTAL_PLUGIN_PATH . '/templates/api_subscribe_form.php';
-		return ob_get_clean();
-	}
-	else {
-		$login_page = get_page_by_path('log-in');
-		return sprintf(__('This page is only available when you are <a href="%1$s">logged in</a>.', Tyk_Dev_Portal::TEXT_DOMAIN), get_permalink($login_page));
-	}
+function tyk_dev_portal_dashboard()
+{
+    $user = new Tyk_Portal_User();
+    if ($user->is_logged_in()) {
+        ob_start();
+
+        include_once TYK_DEV_PORTAL_PLUGIN_PATH . '/templates/api_subscribe_form.php';
+
+        return ob_get_clean();
+    }
+
+    $login_page = get_page_by_path('log-in');
+
+    return sprintf(__('This page is only available when you are <a href="%1$s">logged in</a>.', Tyk_Dev_Portal::TEXT_DOMAIN), get_permalink($login_page));
 }

--- a/templates/api_subscribe_form.php
+++ b/templates/api_subscribe_form.php
@@ -7,13 +7,13 @@
 
 	<ul class="nav nav-tabs" role="tablist">
 		<li role="presentation" class="active">
-			<a href="#tokens-tab" aria-controls="tokens-tab" role="tab" data-toggle="tab"><?php _e('Tokens', Tyk_Dev_Portal::TEXT_DOMAIN)?></a>
+			<a href="#tokens-tab" aria-controls="tokens-tab" role="tab" data-toggle="tab"><?php _e('Tokens', Tyk_Dev_Portal::TEXT_DOMAIN); ?></a>
 		</li>
 		<li role="presentation">
-			<a href="#usage-tab" v-el:usage-tab aria-controls="usage-tab" role="tab" data-toggle="tab"><?php _e('Usage', Tyk_Dev_Portal::TEXT_DOMAIN)?></a>
+			<a href="#usage-tab" v-el:usage-tab aria-controls="usage-tab" role="tab" data-toggle="tab"><?php _e('Usage', Tyk_Dev_Portal::TEXT_DOMAIN); ?></a>
 		</li>
 		<li role="presentation">
-			<a href="#quota-tab" v-el:quoata-tab aria-controls="quoata-tab" role="tab" data-toggle="tab"><?php _e('Quota', Tyk_Dev_Portal::TEXT_DOMAIN)?></a>
+			<a href="#quota-tab" v-el:quoata-tab aria-controls="quoata-tab" role="tab" data-toggle="tab"><?php _e('Quota', Tyk_Dev_Portal::TEXT_DOMAIN); ?></a>
 		</li>
 	</ul>
 

--- a/templates/tab_quota.php
+++ b/templates/tab_quota.php
@@ -4,13 +4,13 @@
 	<quota-tab inline-template>
 		<div class="row">
 			<div class="col-md-8">		
-				<h3><?php _e('Remaining quota', Tyk_Dev_Portal::TEXT_DOMAIN)?></h3>
+				<h3><?php _e('Remaining quota', Tyk_Dev_Portal::TEXT_DOMAIN); ?></h3>
 					<input 
 						type="text" 
 						class="form-control" 
 						v-model="key" 
-						placeholder="<?php _e('Please enter your token here', Tyk_Dev_Portal::TEXT_DOMAIN)?>" @keyup.enter="getQuotas()">
-					<span class="help-block" v-show="busy"><?php _e('loading', Tyk_Dev_Portal::TEXT_DOMAIN)?></span>
+						placeholder="<?php _e('Please enter your token here', Tyk_Dev_Portal::TEXT_DOMAIN); ?>" @keyup.enter="getQuotas()">
+					<span class="help-block" v-show="busy"><?php _e('loading', Tyk_Dev_Portal::TEXT_DOMAIN); ?></span>
 
 				<div style="margin-top: 1em;">
 					<div class="alert alert-danger" v-show="error">{{error}}</div>

--- a/templates/tab_tokens.php
+++ b/templates/tab_tokens.php
@@ -1,7 +1,7 @@
 <div class="tab-pane active" id="tokens-tab">
 
 	<!-- list of user tokens -->
-	<h3><?php _e('My tokens', Tyk_Dev_Portal::TEXT_DOMAIN)?></h3>
+	<h3><?php _e('My tokens', Tyk_Dev_Portal::TEXT_DOMAIN); ?></h3>
 
 	<!-- area for messages -->
 	<div v-cloak>
@@ -9,7 +9,7 @@
 			{{ message }}
 		</div>
 		<div id="tyk-subscribe-error" class="alert alert-danger" v-if="hasError" role="alert">
-			<?php _e('An error occurred. Please try again.', Tyk_Dev_Portal::TEXT_DOMAIN)?>
+			<?php _e('An error occurred. Please try again.', Tyk_Dev_Portal::TEXT_DOMAIN); ?>
 		</div>
 	</div>
 
@@ -17,9 +17,9 @@
 		<table class="table">
 			<thead>
 				<tr>
-					<th><?php _e('Name', Tyk_Dev_Portal::TEXT_DOMAIN)?></th>
-					<th><?php _e('API', Tyk_Dev_Portal::TEXT_DOMAIN)?></th>
-					<th class="icon"><?php _e('State', Tyk_Dev_Portal::TEXT_DOMAIN)?></th>
+					<th><?php _e('Name', Tyk_Dev_Portal::TEXT_DOMAIN); ?></th>
+					<th><?php _e('API', Tyk_Dev_Portal::TEXT_DOMAIN); ?></th>
+					<th class="icon"><?php _e('State', Tyk_Dev_Portal::TEXT_DOMAIN); ?></th>
 					<th class="icon"></th>
 				</tr>
 			</thead>
@@ -29,10 +29,10 @@
 					<td>{{ getApiName(token.api_id) }}</td>
 					<td><span class="label" :class="{'label-danger': !token.is_valid, 'label-success': token.is_valid}">{{ getState(token) }}</span></td>
 					<td>
-						<a href="#" @click.prevent="showUsageTab(token)" class="btn text-info" title="<?php _e('Show usage', Tyk_Dev_Portal::TEXT_DOMAIN)?>">
+						<a href="#" @click.prevent="showUsageTab(token)" class="btn text-info" title="<?php _e('Show usage', Tyk_Dev_Portal::TEXT_DOMAIN); ?>">
 							<span class="glyphicon glyphicon-stats"></span>
 						</a>
-						<a href="#revoke" @click.prevent="revokeToken(token)" class="btn text-danger" title="<?php _e('Revoke this token', Tyk_Dev_Portal::TEXT_DOMAIN)?>">
+						<a href="#revoke" @click.prevent="revokeToken(token)" class="btn text-danger" title="<?php _e('Revoke this token', Tyk_Dev_Portal::TEXT_DOMAIN); ?>">
 							<span class="glyphicon glyphicon-trash"></span>
 						</a>
 					</td>
@@ -43,10 +43,10 @@
 	<table class="table" v-else>
 		<tbody>
 			<tr v-if="loading">
-				<td colspan="3"><?php _e("loading", Tyk_Dev_Portal::TEXT_DOMAIN)?></td>
+				<td colspan="3"><?php _e('loading', Tyk_Dev_Portal::TEXT_DOMAIN); ?></td>
 			</tr>
 			<tr v-else>
-				<td colspan="3"><?php _e("You don't have any tokens yet", Tyk_Dev_Portal::TEXT_DOMAIN)?></td>
+				<td colspan="3"><?php _e("You don't have any tokens yet", Tyk_Dev_Portal::TEXT_DOMAIN); ?></td>
 			</tr>
 		</tbody>
 	</table>
@@ -56,8 +56,8 @@
 
 			<!-- request an access token for an api -->
 			<request-token-form inline-template :apis="availableApis" :subscribed-apis.sync="subscribedApis">
-				<form action="<?php echo esc_url( admin_url('admin-post.php') ); ?>" class="form-horizontal" method="post">
-					<h3><?php _e('Request a token', Tyk_Dev_Portal::TEXT_DOMAIN)?></h3>
+				<form action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="form-horizontal" method="post">
+					<h3><?php _e('Request a token', Tyk_Dev_Portal::TEXT_DOMAIN); ?></h3>
 
 					<!-- area for messages -->
 					<div v-cloak>
@@ -66,22 +66,22 @@
 							{{message}}
 						</div>
 						<div id="tyk-subscribe-error" class="alert alert-danger" v-if="hasError" role="alert">
-							<?php _e('An error occurred. Please try again.', Tyk_Dev_Portal::TEXT_DOMAIN)?>
+							<?php _e('An error occurred. Please try again.', Tyk_Dev_Portal::TEXT_DOMAIN); ?>
 						</div>
 					</div>
 
 					<div class="form-group">
-						<label for="tyk-token-name" class="col-xs-2"><?php _e('Name', Tyk_Dev_Portal::TEXT_DOMAIN)?></label>
+						<label for="tyk-token-name" class="col-xs-2"><?php _e('Name', Tyk_Dev_Portal::TEXT_DOMAIN); ?></label>
 						<div class="col-xs-10">
-							<input type="text" v-model="token_name" name="token_name" class="form-control" id="tyk-token-name" placeholder="<?php _e('Give this token a name', Tyk_Dev_Portal::TEXT_DOMAIN)?>" />
+							<input type="text" v-model="token_name" name="token_name" class="form-control" id="tyk-token-name" placeholder="<?php _e('Give this token a name', Tyk_Dev_Portal::TEXT_DOMAIN); ?>" />
 						</div>
 					</div>	
 
 					<div class="form-group">
-						<label for="tyk-api-select" class="col-xs-2"><?php _e('API', Tyk_Dev_Portal::TEXT_DOMAIN)?></label>
+						<label for="tyk-api-select" class="col-xs-2"><?php _e('API', Tyk_Dev_Portal::TEXT_DOMAIN); ?></label>
 						<div class="col-xs-10">
 							<select name="api" id="tyk-api-select" class="form-control" v-model="api">
-								<option value=""><?php _e('-- please choose', Tyk_Dev_Portal::TEXT_DOMAIN)?></option>
+								<option value=""><?php _e('-- please choose', Tyk_Dev_Portal::TEXT_DOMAIN); ?></option>
 								<option v-for="api in apis" value="{{ api.id }}" :disabled="hasTokenForAPI(api.id)">{{ api.name }}</option>
 							</select>
 						</div>
@@ -91,7 +91,7 @@
                         <div class="col-xs-2"></div>
                         <div class="col-xs-10">
                             <input type="checkbox" id="tyk-api-tac" name="tyk-api-tac" v-model="tac_accepted">
-                            <label for="tyk-api-tac"><?php _e('I accept the general terms and conditions', Tyk_Dev_Portal::TEXT_DOMAIN)?></label>
+                            <label for="tyk-api-tac"><?php _e('I accept the general terms and conditions', Tyk_Dev_Portal::TEXT_DOMAIN); ?></label>
                         </div>
                     </div>
 
@@ -99,10 +99,10 @@
 						<div class="col-xs-10 col-xs-offset-2">
 							<button @click.prevent="register" :disabled="busy || !formValid" id="btn-tyk-api-subscribe" class="btn btn-primary">
 								<template v-if="busy">
-									<?php _e('loading', Tyk_Dev_Portal::TEXT_DOMAIN)?>
+									<?php _e('loading', Tyk_Dev_Portal::TEXT_DOMAIN); ?>
 								</template>
 								<template v-else>
-									<?php _e('Request a token', Tyk_Dev_Portal::TEXT_DOMAIN)?>
+									<?php _e('Request a token', Tyk_Dev_Portal::TEXT_DOMAIN); ?>
 								</template>
 							</button>
 						</div>

--- a/templates/tab_usage.php
+++ b/templates/tab_usage.php
@@ -4,20 +4,20 @@
 	<usage-tab inline-template :tokens="tokens">
 		<div class="row">
 			<div class="col-md-8">
-				<h3><?php _e('Token', Tyk_Dev_Portal::TEXT_DOMAIN)?></h3>
+				<h3><?php _e('Token', Tyk_Dev_Portal::TEXT_DOMAIN); ?></h3>
 				<select class="form-control" v-model="form.token">
-					<option value=""><?php _e('-- please choose', Tyk_Dev_Portal::TEXT_DOMAIN)?></option>
+					<option value=""><?php _e('-- please choose', Tyk_Dev_Portal::TEXT_DOMAIN); ?></option>
 					<option v-for="token in tokens" value="{{ token.hash }}">{{ token.token_name }}</option>
 				</select>
 				
 				<div class="row">
 					<div class="col-xs-6">
-						<label for="tyk-usage-from"><?php _e('From', Tyk_Dev_Portal::TEXT_DOMAIN)?></label>
+						<label for="tyk-usage-from"><?php _e('From', Tyk_Dev_Portal::TEXT_DOMAIN); ?></label>
 						<input id="tyk-usage-from" type="date" class="form-control" v-model="form.fromDate" @blur="fetchUsage">
 					</div>
 
 					<div class="col-xs-6">
-						<label for="tyk-usage-to"><?php _e('To', Tyk_Dev_Portal::TEXT_DOMAIN)?></label>
+						<label for="tyk-usage-to"><?php _e('To', Tyk_Dev_Portal::TEXT_DOMAIN); ?></label>
 						<input id="tyk-usage-to" type="date" class="form-control" v-model="form.toDate" @blur="fetchUsage">
 					</div>
 				</div>

--- a/tests/ApiManagerTest.php
+++ b/tests/ApiManagerTest.php
@@ -1,21 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'TykDevPortalTestcase.php';
 
-class TykAPIManagerTest extends Tyk_Dev_Portal_Testcase {
-	// test getting policies
-	function testAvailablePolicies() {
-		$apiManager = new Tyk_API_Manager;
-		$apis = $apiManager->available_policies();
-		$this->assertTrue(is_array($apis));
-		$this->assertTrue(sizeof($apis) > 0);
-	}
+class TykAPIManagerTest extends Tyk_Dev_Portal_Testcase
+{
+    // test getting policies
+    public function testAvailablePolicies(): void
+    {
+        $apiManager = new Tyk_API_Manager();
+        $apis = $apiManager->available_policies();
+        $this->assertIsArray($apis);
+        $this->assertTrue(sizeof($apis) > 0);
+    }
 
-	// test getting apis
-	function testAvailableApis() {
-		$apiManager = new Tyk_API_Manager;
-		$apis = $apiManager->available_apis();
-		$this->assertTrue(is_array($apis));
-		$this->assertTrue(sizeof($apis) > 0);
-	}
+    // test getting apis
+    public function testAvailableApis(): void
+    {
+        $apiManager = new Tyk_API_Manager();
+        $apis = $apiManager->available_apis();
+        $this->assertIsArray($apis);
+        $this->assertTrue(sizeof($apis) > 0);
+    }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,23 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'TykDevPortalTestcase.php';
 
-class TykDevPortalPluginTest extends Tyk_Dev_Portal_Testcase {
-	// test if developer role can be created
-	function testRoleCreation() {
-		$plugin = new Tyk_Dev_Portal();
-		$plugin->create_developer_role();
+class TykDevPortalPluginTest extends Tyk_Dev_Portal_Testcase
+{
+    // test if developer role can be created
+    public function testRoleCreation(): void
+    {
+        $plugin = new Tyk_Dev_Portal();
+        $plugin->create_developer_role();
 
-		$role = get_role($plugin::DEVELOPER_ROLE_NAME);
-		$this->assertInstanceOf('WP_Role', $role);
-	}
+        $role = get_role($plugin::DEVELOPER_ROLE_NAME);
+        $this->assertInstanceOf('WP_Role', $role);
+    }
 
-	// test that dashboard page can be created
-	function testDashboardPageCreation() {
-		$plugin = new Tyk_Dev_Portal();
-		$plugin->create_dashboard_page();
+    // test that dashboard page can be created
+    public function testDashboardPageCreation(): void
+    {
+        $plugin = new Tyk_Dev_Portal();
+        $plugin->create_dashboard_page();
 
-		$page = get_page_by_path($plugin::DASHBOARD_SLUG);
-		$this->assertInstanceOf('WP_Post', $page);
-	}
+        $page = get_page_by_path($plugin::DASHBOARD_SLUG);
+        $this->assertInstanceOf('WP_Post', $page);
+    }
 }

--- a/tests/PortalUserTest.php
+++ b/tests/PortalUserTest.php
@@ -1,126 +1,138 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'TykDevPortalTestcase.php';
 
-class TykPortalUserTest extends Tyk_Dev_Portal_Testcase {
-	// test the check if a user is a developer
-	function testIsDeveloperCheck() {
-		// create a new user with developer role
-		$user_id = $this->createTestUser();
-		$this->assertGreaterThanOrEqual(1, $user_id);
+class TykPortalUserTest extends Tyk_Dev_Portal_Testcase
+{
+    // test the check if a user is a developer
+    public function testIsDeveloperCheck(): void
+    {
+        // create a new user with developer role
+        $user_id = $this->createTestUser();
+        $this->assertGreaterThanOrEqual(1, $user_id);
 
-		// make sure our check gets it right
-		$user = new Tyk_Portal_User($user_id);
-		$this->assertTrue($user->is_developer());
-	}
+        // make sure our check gets it right
+        $user = new Tyk_Portal_User($user_id);
+        $this->assertTrue($user->is_developer());
+    }
 
-	// test developer registration with tyk
-	function testTykRegistration() {
-		// create a new user with developer role
-		$user_id = $this->createTestUser();
-		$this->assertGreaterThanOrEqual(1, $user_id);
+    // test developer registration with tyk
+    public function testTykRegistration(): void
+    {
+        // create a new user with developer role
+        $user_id = $this->createTestUser();
+        $this->assertGreaterThanOrEqual(1, $user_id);
 
-		$user = new Tyk_Portal_User($user_id);
-		$user->register_with_tyk();
-		$tyk_id = $user->get_tyk_id();
-		
-		// it's hard to check if the id is valid, but let's make sure 
-		// it's not empty and is at leaast 5 chars long
-		$this->assertNotEmpty($tyk_id);
-		$this->assertTrue(strlen($tyk_id) > 5);
-	}
+        $user = new Tyk_Portal_User($user_id);
+        $user->register_with_tyk();
+        $tyk_id = $user->get_tyk_id();
 
-	// test adding an access token
-	// @todo test adding token that already exists (same token_id)
-	// @todo test adding multiple tokens and make sure they all get saved
-	function testAddAccessToken() {
-		$user = $this->createPortalUser();
-		// save a token
-		$testToken = array(
-			'api_id' => 'api-id',
-			'token_name' => 'Unittest Token',
-			'hash' => 'token-id',
-			);
-		$user->save_access_token($testToken['api_id'], $testToken['token_name'], $testToken['hash']);
+        // it's hard to check if the id is valid, but let's make sure
+        // it's not empty and is at leaast 5 chars long
+        $this->assertNotEmpty($tyk_id);
+        $this->assertTrue(strlen($tyk_id) > 5);
+    }
 
-		// save it again to check that it updates and doesn't duplicate
-		$user->save_access_token($testToken['api_id'], $testToken['token_name'], $testToken['hash']);		
+    // test adding an access token
+    // @todo test adding token that already exists (same token_id)
+    // @todo test adding multiple tokens and make sure they all get saved
+    public function testAddAccessToken(): void
+    {
+        $user = $this->createPortalUser();
+        // save a token
+        $testToken = array(
+            'api_id' => 'api-id',
+            'token_name' => 'Unittest Token',
+            'hash' => 'token-id',
+        );
+        $user->save_access_token($testToken['api_id'], $testToken['token_name'], $testToken['hash']);
 
-		// get all tokens
-		$tokens = $user->get_access_tokens();
+        // save it again to check that it updates and doesn't duplicate
+        $user->save_access_token($testToken['api_id'], $testToken['token_name'], $testToken['hash']);
 
-		// make sure it didn't duplicate
-		$this->assertEquals(count($tokens), 1);
-		$this->assertArraySubset(array($testToken), $tokens);
-	}
+        // get all tokens
+        $tokens = $user->get_access_tokens();
 
-	// make sure we always get an array of access tokens
-	function testGetAccessTokens() {
-		$user = $this->createPortalUser();
+        // make sure it didn't duplicate
+        $this->assertEquals(count($tokens), 1);
+        $this->assertArraySubset(array($testToken), $tokens);
+    }
 
-		$this->assertTrue(is_array($user->get_access_tokens()));
-	}
+    // make sure we always get an array of access tokens
+    public function testGetAccessTokens(): void
+    {
+        $user = $this->createPortalUser();
 
-	// test that we can delete tokens
-	function testDeleteAccessToken() {
-		$user = $this->createPortalUser();
-		
-		// let's add three tokens
-		$user->save_access_token('api-id', 'My favorite token', 'token-id-1');
-		$user->save_access_token('api-id', 'My 2nd-favorite token', 'token-id-2');
-		$user->save_access_token('api-id', 'My 3rd-favorite token', 'token-id-3');
+        $this->assertIsArray($user->get_access_tokens());
+    }
 
-		$tokens = $user->get_access_tokens();
-		$this->assertEquals(count($tokens), 3);
+    // test that we can delete tokens
+    public function testDeleteAccessToken(): void
+    {
+        $user = $this->createPortalUser();
 
-		// delete the 2nd one
-		$user->delete_access_token('token-id-2');
+        // let's add three tokens
+        $user->save_access_token('api-id', 'My favorite token', 'token-id-1');
+        $user->save_access_token('api-id', 'My 2nd-favorite token', 'token-id-2');
+        $user->save_access_token('api-id', 'My 3rd-favorite token', 'token-id-3');
 
-		$tokens = $user->get_access_tokens();
-		$found = false;
-		foreach ($tokens as $token) {
-			if ($token['hash'] == 'token-id-2') {
-				$found = true;
-			}
-		}
-		$this->assertFalse($found);
-		$this->assertEquals(count($tokens), 2);
-	}
+        $tokens = $user->get_access_tokens();
+        $this->assertEquals(count($tokens), 3);
 
-	// test getting a token
-	function testGetExistingToken() {
-		$user = $this->createPortalUser();
-		// save a token
-		$testToken = array(
-			'api_id' => 'api-id',
-			'token_name' => 'Unittest Token',
-			'hash' => 'token-id-4',
-			);
-		$user->save_access_token($testToken['api_id'], $testToken['token_name'], $testToken['hash']);
+        // delete the 2nd one
+        $user->delete_access_token('token-id-2');
 
-		$token = $user->get_access_token($testToken['hash']);
+        $tokens = $user->get_access_tokens();
+        $found = false;
+        foreach ($tokens as $token) {
+            if ('token-id-2' == $token['hash']) {
+                $found = true;
+            }
+        }
+        $this->assertFalse($found);
+        $this->assertEquals(count($tokens), 2);
+    }
 
-		$this->assertInstanceOf('Tyk_Token', $token);
-		// note: the token name isn't relevant for the Tyk_Token class
-		$this->assertEquals($token->get_hash(), $testToken['hash']);
-		$this->assertEquals($token->get_policy(), $testToken['api_id']);
-	}
+    // test getting a token
+    public function testGetExistingToken(): void
+    {
+        $user = $this->createPortalUser();
+        // save a token
+        $testToken = array(
+            'api_id' => 'api-id',
+            'token_name' => 'Unittest Token',
+            'hash' => 'token-id-4',
+        );
+        $user->save_access_token($testToken['api_id'], $testToken['token_name'], $testToken['hash']);
 
-	/**
-	 * test that you can't get a on existent token
-	 * @expectedException OutOfBoundsException
-	 */
-	function testGetNonExistentToken() {
-		$user = $this->createPortalUser();
-		$user->get_access_token("surely this won't work");
-	}
+        $token = $user->get_access_token($testToken['hash']);
 
-	// test if we can pull user data from tyk
-	function testFetchUserFromTyk() {
-		$user = $this->createPortalUser();
+        $this->assertInstanceOf('Tyk_Token', $token);
+        // note: the token name isn't relevant for the Tyk_Token class
+        $this->assertEquals($token->get_hash(), $testToken['hash']);
+        $this->assertEquals($token->get_policy(), $testToken['api_id']);
+    }
 
-		$developer = $user->fetch_from_tyk();
-		$this->assertInstanceOf('stdClass', $developer);
-		$this->assertEquals($developer->id, $user->get_tyk_id());
-	}
+    /**
+     * test that you can't get a on existent token.
+     *
+     * @expectedException \OutOfBoundsException
+     */
+    public function testGetNonExistentToken(): void
+    {
+        $user = $this->createPortalUser();
+        $user->get_access_token("surely this won't work");
+    }
+
+    // test if we can pull user data from tyk
+    public function testFetchUserFromTyk(): void
+    {
+        $user = $this->createPortalUser();
+
+        $developer = $user->fetch_from_tyk();
+        $this->assertInstanceOf('stdClass', $developer);
+        $this->assertEquals($developer->id, $user->get_tyk_id());
+    }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -1,133 +1,148 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'TykDevPortalTestcase.php';
 
-class TokenTest extends Tyk_Dev_Portal_Testcase {
-	// test making a key request for an api policy
-	function testKeyRequest() {
-		$user = $this->createPortalUser();
-		
-		$token = new Tyk_Token($user, TYK_TEST_API_POLICY);
-		$token->request();
+class TokenTest extends Tyk_Dev_Portal_Testcase
+{
+    // test making a key request for an api policy
+    public function testKeyRequest(): void
+    {
+        $user = $this->createPortalUser();
 
-		// it's hard to check if the key is valid, but let's make sure 
-		// it's not empty and is at leaast 5 chars long
-		$this->assertNotEmpty($token->get_id());
-		$this->assertTrue(strlen($token->get_id()) > 5);
-	}
+        $token = new Tyk_Token($user, TYK_TEST_API_POLICY);
+        $token->request();
 
-	/**
-	 * Disabled because Tyk API doesn't care if the policy exists or not
-	 * @see https://github.com/TykTechnologies/tyk/issues/272
-	 * expectedException UnexpectedValueException
-	 *
-	function testInvalidKeyRequest() {
-		$user = $this->createPortalUser();
-		
-		$token = new Tyk_Token($user, 'invalid api');
-		$token->request();
-		print $token->get_id();
-	}*/
+        // it's hard to check if the key is valid, but let's make sure
+        // it's not empty and is at leaast 5 chars long
+        $this->assertNotEmpty($token->get_id());
+        $this->assertTrue(strlen($token->get_id()) > 5);
+    }
 
-	// test making and approving a key request to get an access token
-	// @todo test failure when using an invalid key
-	function testKeyApproval() {
-		$user = $this->createPortalUser();
+    /**
+     * Disabled because Tyk API doesn't care if the policy exists or not.
+     *
+     * @see https://github.com/TykTechnologies/tyk/issues/272
+     * expectedException UnexpectedValueException
+     *
+     * function testInvalidKeyRequest() {
+     * $user = $this->createPortalUser();
+     *
+     * $token = new Tyk_Token($user, 'invalid api');
+     * $token->request();
+     * print $token->get_id();
+     * }*/
 
-		$token = new Tyk_Token($user, TYK_TEST_API_POLICY);
-		$token->request();
-		$token->approve();
-		
-		// it's hard to check if the token is valid, but let's make sure 
-		// it's not empty and is at leaast 5 chars long
-		$this->assertNotEmpty($token->get_key());
-		$this->assertTrue(strlen($token->get_key()) > 5);
-		$this->assertNotEmpty($token->get_hash());
-		$this->assertTrue(strlen($token->get_hash()) > 5);
-	}
+    // test making and approving a key request to get an access token
+    // @todo test failure when using an invalid key
+    public function testKeyApproval(): void
+    {
+        $user = $this->createPortalUser();
 
-	/**
-	 * test that you can't approve a key without an id
-	 * @expectedException InvalidArgumentException
-	 */
-	function testEmptyKeyApproval() {
-		$user = $this->createPortalUser();
+        $token = new Tyk_Token($user, TYK_TEST_API_POLICY);
+        $token->request();
+        $token->approve();
 
-		$token = new Tyk_Token($user, TYK_TEST_API_POLICY);
-		$token->request();
-		// let's set the internal id to something invalid
-		$token->set_id(null);
-		$token->approve();
-	}
+        // it's hard to check if the token is valid, but let's make sure
+        // it's not empty and is at leaast 5 chars long
+        $this->assertNotEmpty($token->get_key());
+        $this->assertTrue(strlen($token->get_key()) > 5);
+        $this->assertNotEmpty($token->get_hash());
+        $this->assertTrue(strlen($token->get_hash()) > 5);
+    }
 
-	/**
-	 * test that you can't approve an invalid key
-	 * @expectedException UnexpectedValueException
-	 */
-	function testInvalidKeyApproval() {
-		$user = $this->createPortalUser();
+    /**
+     * test that you can't approve a key without an id.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testEmptyKeyApproval(): void
+    {
+        $user = $this->createPortalUser();
 
-		$token = new Tyk_Token($user, TYK_TEST_API_POLICY);
-		$token->request();
-		// let's set the internal id to an id that isn't on tyk
-		$token->set_id('not an actual id');
-		$token->approve();
-	}
+        $token = new Tyk_Token($user, TYK_TEST_API_POLICY);
+        $token->request();
+        // let's set the internal id to something invalid
+        $token->set_id(null);
+        $token->approve();
+    }
 
-	/**
-	 * test that we can't instantiate a token with invalid values
-	 * @expectedException InvalidArgumentException
-	 */
-	function testInvalidTokenInstantiation() {
-		$user = $this->createPortalUser();
-		$token = Tyk_Token::init(array('foo' => 'bar'), $user);
-	}
+    /**
+     * test that you can't approve an invalid key.
+     *
+     * @expectedException \UnexpectedValueException
+     */
+    public function testInvalidKeyApproval(): void
+    {
+        $user = $this->createPortalUser();
 
-	// test revoking a key
-	function testRevokeKey() {
-		$user = $this->createPortalUser();
+        $token = new Tyk_Token($user, TYK_TEST_API_POLICY);
+        $token->request();
+        // let's set the internal id to an id that isn't on tyk
+        $token->set_id('not an actual id');
+        $token->approve();
+    }
 
-		// request a token
-		$token = new Tyk_Token($user, TYK_TEST_API_POLICY);
-		$token->request();
-		
-		// approve it
-		$token->approve();
-		$this->assertNotEmpty($token->get_key());
-		$this->assertTrue(strlen($token->get_key()) > 5);
+    /**
+     * test that we can't instantiate a token with invalid values.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidTokenInstantiation(): void
+    {
+        $user = $this->createPortalUser();
+        $token = Tyk_Token::init(array('foo' => 'bar'), $user);
+    }
 
-		// revoke it
-		$this->assertTrue($token->revoke());
-	}
+    // test revoking a key
+    public function testRevokeKey(): void
+    {
+        $user = $this->createPortalUser();
 
-	// test getting usage quota of a token
-	function testUsageQuota() {
-		$user = $this->createPortalUser();
+        // request a token
+        $token = new Tyk_Token($user, TYK_TEST_API_POLICY);
+        $token->request();
 
-		// create a token first
-		$token = new Tyk_Token($user, TYK_TEST_API_POLICY);
-		$token->request();
-		$token->approve();
+        // approve it
+        $token->approve();
+        $this->assertNotEmpty($token->get_key());
+        $this->assertTrue(strlen($token->get_key()) > 5);
 
-		$token = Tyk_Token::init_from_key($token->get_key(), $user);
-		$data = $token->get_usage_quota();
+        // revoke it
+        $this->assertTrue($token->revoke());
+    }
 
-		$this->assertTrue(is_object($data));
-	}
+    // test getting usage quota of a token
+    public function testUsageQuota(): void
+    {
+        $user = $this->createPortalUser();
 
-	// test getting usage stats of a token
-	function testUsageStats() {
-		$user = $this->createPortalUser();
+        // create a token first
+        $token = new Tyk_Token($user, TYK_TEST_API_POLICY);
+        $token->request();
+        $token->approve();
 
-		// create a token first
-		$token = new Tyk_Token($user, TYK_TEST_API_POLICY);
-		$token->request();
-		$token->approve();
+        $token = Tyk_Token::init_from_key($token->get_key(), $user);
+        $data = $token->get_usage_quota();
 
-		$data = $token->get_usage();
+        $this->assertIsObject($data);
+    }
 
-		// this doesn't make a lot of sense like this but $data will be null if we don't use the token
-		// but at least we didn't get an exception if we got this far
-		$this->assertTrue(is_object($data) || is_null($data));
-	}
+    // test getting usage stats of a token
+    public function testUsageStats(): void
+    {
+        $user = $this->createPortalUser();
+
+        // create a token first
+        $token = new Tyk_Token($user, TYK_TEST_API_POLICY);
+        $token->request();
+        $token->approve();
+
+        $data = $token->get_usage();
+
+        // this doesn't make a lot of sense like this but $data will be null if we don't use the token
+        // but at least we didn't get an exception if we got this far
+        $this->assertTrue(is_object($data) || is_null($data));
+    }
 }

--- a/tests/TykDevPortalTestcase.php
+++ b/tests/TykDevPortalTestcase.php
@@ -1,56 +1,62 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
+declare(strict_types=1);
 
 /**
- * Base class for tyk portal plugin test cases
+ * Base class for tyk portal plugin test cases.
  *
  * @see https://github.com/10up/wp_mock Maybe expand tests later on
  * @see https://wordpress.stackexchange.com/questions/164121/testing-hooks-callback
  */
-abstract class Tyk_Dev_Portal_Testcase extends WP_UnitTestCase {
-	/**
-	 * Create a new user, registered with Tyk and ready for testing
-	 * 
-	 * @return Tyk_Portal_User
-	 */
-	protected function createPortalUser() {
-		// create a new user with developer role
-		$user_id = $this->createTestUser();
-		$this->assertGreaterThanOrEqual(1, $user_id);
+abstract class Tyk_Dev_Portal_Testcase extends WP_UnitTestCase
+{
+    /**
+     * Create a new user, registered with Tyk and ready for testing.
+     *
+     * @return Tyk_Portal_User
+     */
+    protected function createPortalUser()
+    {
+        // create a new user with developer role
+        $user_id = $this->createTestUser();
+        $this->assertGreaterThanOrEqual(1, $user_id);
 
-		$user = new Tyk_Portal_User($user_id);
-		$user->register_with_tyk();
-		$this->assertTrue($user->has_tyk_id());
+        $user = new Tyk_Portal_User($user_id);
+        $user->register_with_tyk();
+        $this->assertTrue($user->has_tyk_id());
 
-		return $user;
-	}
+        return $user;
+    }
 
-	/**
-	 * Create a test wordpress user
-	 * 
-	 * @return integer User ID
-	 */
-	protected function createTestUser() {
-		return wp_insert_user(array(
-			'user_login' => 'test_developer',
-			'user_pass' => '123456789',
-			'user_email' => 'unittest@example.org',
-			'role' => 'developer',
-			));
-	}
+    /**
+     * Create a test wordpress user.
+     *
+     * @return int User ID
+     */
+    protected function createTestUser()
+    {
+        return wp_insert_user(array(
+            'user_login' => 'test_developer',
+            'user_pass' => '123456789',
+            'user_email' => 'unittest@example.org',
+            'role' => 'developer',
+        ));
+    }
 
-	/**
-	 * Get access to a protected method of a class
-	 * 
-	 * @param string $class
-	 * @param string $method
-	 * @return ReflectionMethod
-	 */
-	protected function getProtectedMethod($class, $method) {
-		$class = new ReflectionClass($class);
-		$method = $class->getMethod($method);
-		$method->setAccessible(true);
-		return $method;
-	}
+    /**
+     * Get access to a protected method of a class.
+     *
+     * @param string $class
+     * @param string $method
+     *
+     * @return ReflectionMethod
+     */
+    protected function getProtectedMethod($class, $method)
+    {
+        $class = new ReflectionClass($class);
+        $method = $class->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method;
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,13 +1,14 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * PHPUnit bootstrap file
- * bash bin/install-wp-tests.sh wp_test root '' localhost latest
- * @package Tyk_Dev_Portal
+ * bash bin/install-wp-tests.sh wp_test root '' localhost latest.
  */
-
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
-if ( ! $_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
+$_tests_dir = getenv('WP_TESTS_DIR');
+if (! $_tests_dir) {
+    $_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
 // Give access to tests_add_filter() function.
@@ -16,17 +17,16 @@ require_once $_tests_dir . '/includes/functions.php';
 /**
  * Manually load the plugin being tested.
  */
-function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/tyk_dev_portal.php';
+function _manually_load_plugin(): void
+{
+    require dirname(dirname(__FILE__)) . '/tyk_dev_portal.php';
 }
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+tests_add_filter('muplugins_loaded', '_manually_load_plugin');
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 
-
-
-define( 'TYK_API_ENDPOINT', '' );
-define( 'TYK_API_KEY', '' );  // add a key for a management user
-define( 'TYK_AUTO_APPROVE_KEY_REQUESTS', true );
-define( 'TYK_TEST_API_POLICY', '' );  // add the id of a test api policy tagged with 'allow_regsitration'
+define('TYK_API_ENDPOINT', '');
+define('TYK_API_KEY', '');  // add a key for a management user
+define('TYK_AUTO_APPROVE_KEY_REQUESTS', true);
+define('TYK_TEST_API_POLICY', '');  // add the id of a test api policy tagged with 'allow_regsitration'

--- a/tyk_dev_portal.php
+++ b/tyk_dev_portal.php
@@ -1,27 +1,37 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Plugin Name: Tyk Developer Portal
  * Description: Integrates a developer portal of a Tyk API Gateway in your WordPress site
  * Author: Liip <be-dev@liip.ch>
  * Version: 1.3.0
  * Date: 20.02.2020
- * Text Domain: tyk-dev-portal
+ * Text Domain: tyk-dev-portal.
  */
+defined('ABSPATH') or exit('No script kiddies please!');
 
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
-
-define('TYK_DEV_PORTAL_PLUGIN_PATH', dirname( __FILE__ ));
+define('TYK_DEV_PORTAL_PLUGIN_PATH', dirname(__FILE__));
 define('TYK_DEV_PORTAL_TPL_PATH', TYK_DEV_PORTAL_PLUGIN_PATH . '/templates');
 define('TYK_DEV_PORTAL_PLUGIN_FILE', __FILE__);
 
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/dev_portal.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/portal_user.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/api_manager.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/dashboard_ajax_provider.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/token.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/tyk_interaction.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/tyk_api.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/classes/tyk_gateway.php';
+
 require_once TYK_DEV_PORTAL_PLUGIN_PATH . '/template_tags.php';
 
 $plugin = new Tyk_Dev_Portal();
@@ -30,11 +40,13 @@ $plugin->register_actions();
 $plugin->register_shortcodes();
 
 /**
- * Get url to this plugin's dir
+ * Get url to this plugin's dir.
  *
  * @param string $path Path to the plugin file you want the url for
+ *
  * @return string
  */
-function tyk_dev_portal_plugin_url($path) {
-	return plugin_dir_url(__FILE__) . $path;
+function tyk_dev_portal_plugin_url($path)
+{
+    return plugin_dir_url(__FILE__) . $path;
 }


### PR DESCRIPTION
As Tyk has changed their API endpoints since a while, the revoke of a token was not working properly anymore.
This fix solves that and removes old code, that is no longer needed.